### PR TITLE
:bug: apiDataProcessor: properly handle number types

### DIFF
--- a/ui/src/components/queries/ModelListModalQuery.js
+++ b/ui/src/components/queries/ModelListModalQuery.js
@@ -8,7 +8,7 @@ const fetchData = async ({ setState, modelIds }) => {
   const { data } = await api({
     endpoint: `${globals.VERSION}/graphql/ModelDataQuery`,
     body: {
-      query: `query ModelDataQuery($filters: JSON) {
+      query: `query ModelListModal($filters: JSON) {
             models {
               extended
               hits(first: ${modelIds.length} filters: $filters) {

--- a/ui/src/utils/apiDataProcessor.js
+++ b/ui/src/utils/apiDataProcessor.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import { isEmpty } from 'lodash';
 
 const processors = {
   date: value => moment(value).format('DD/MM/YYYY'),
@@ -9,13 +8,23 @@ const processors = {
   short: value => value.toLocaleString(),
 };
 
+const isNullOrUndefined = value => value === null || typeof value === 'undefined';
+const isEmptyByType = {
+  date: value => isNullOrUndefined(value) || !value.length,
+  boolean: isNullOrUndefined,
+  keyword: value => isNullOrUndefined(value) || !value.length,
+  long: isNullOrUndefined,
+  short: isNullOrUndefined,
+};
+
 /**
  * If there is data process it, otherwise return
  * the characters "--" - our convention for no-data
- * @param {*} data - Any object, string, array, we are checking for content
- * @param String displayType - date, boolean, keyword, long
+ * @param {*} data - any of the below types
+ * @param String type - date, boolean, keyword, long, short
  */
-export default ({ data, type, unit }) =>
-  (type !== 'boolean' && !data) || data.length === 0 || isEmpty(data)
+export default ({ data, type, unit }) => {
+  return isEmptyByType[type || 'keyword'](data)
     ? '--'
     : `${processors[type || 'keyword'](data)}${unit ? ` ${unit}` : ''}`;
+};


### PR DESCRIPTION
fields with number type were showing up as '--', i guess at one point they were being passed as strings from arranger so it worked; now they are passed as numbers so the data.length fails. Looks like dates are still passed as strings.