### PR TITLE
:sparkles: validation errors: key by path

### DIFF
--- a/cms/src/routes/sync-data.js
+++ b/cms/src/routes/sync-data.js
@@ -100,7 +100,10 @@ data_sync_router.get('/sync-mongo/:sheetId/:tabName', async (req, res) => {
         const failed = results.filter(result => result instanceof Error);
         if (failed.length > 0) {
           const errors = {
-            validationErrors: failed.map(({ value, errors }) => ({ errors, value })),
+            validationErrors: failed.map(({ value, inner }) => ({
+              errors: inner.reduce((acc, { path, message }) => ({ ...acc, [path]: message }), {}),
+              value,
+            })),
           };
           throw errors;
         }


### PR DESCRIPTION
Forgot that Francois asked for this during the demo meeting. 

errors now look like 
```
"errors": {
"gender": "gender must be one of the following values: female, male, unspecified, unknown",
"race": "race must be one of the following values: american indian or alaskan native, asian, black or african american, native hawaiian or other pacific islander, white, not reported, unknown"
},
```
instead of 
```
"errors": [
"gender must be one of the following values: female, male, unspecified, unknown",
"race must be one of the following values: american indian or alaskan native, asian, black or african american, native hawaiian or other pacific islander, white, not reported, unknown"
],
```