### PR TITLE
:sparkles: preCreate, preUpdate validate

### DIFF
--- a/cms/src/index.js
+++ b/cms/src/index.js
@@ -39,6 +39,7 @@ const validateYup = (req, res, next) => {
 restify.serve(router, Model, {
   preCreate: validateYup,
   preUpdate: validateYup,
+  idProperty: 'model_name',
 });
 
 app.use('/', data_sync_router);

--- a/cms/src/routes/sync-data.js
+++ b/cms/src/routes/sync-data.js
@@ -69,6 +69,26 @@ const removeNullKeys = data =>
     {},
   );
 
+export const runYupValidators = parsed => {
+  const validatePromises = parsed.map(p =>
+    yupSchema.validate(p, { abortEarly: false }).catch(Error => Error),
+  );
+
+  return Promise.all(validatePromises).then(results => {
+    const failed = results.filter(result => result instanceof Error);
+    if (failed.length > 0) {
+      const errors = {
+        validationErrors: failed.map(({ value, inner }) => ({
+          errors: inner.reduce((acc, { path, message }) => ({ ...acc, [path]: message }), {}),
+          value,
+        })),
+      };
+      throw errors;
+    }
+    return parsed;
+  });
+};
+
 data_sync_router.get('/sync-mongo/:sheetId/:tabName', async (req, res) => {
   const authClient = getAuthClient();
   const { sheetId, tabName } = req.params;
@@ -91,25 +111,7 @@ data_sync_router.get('/sync-mongo/:sheetId/:tabName', async (req, res) => {
         .map(d => removeNullKeys(d));
       return parsed;
     })
-    .then(parsed => {
-      const validatePromises = parsed.map(p =>
-        yupSchema.validate(p, { abortEarly: false }).catch(Error => Error),
-      );
-
-      return Promise.all(validatePromises).then(results => {
-        const failed = results.filter(result => result instanceof Error);
-        if (failed.length > 0) {
-          const errors = {
-            validationErrors: failed.map(({ value, inner }) => ({
-              errors: inner.reduce((acc, { path, message }) => ({ ...acc, [path]: message }), {}),
-              value,
-            })),
-          };
-          throw errors;
-        }
-        return parsed;
-      });
-    })
+    .then(runYupValidators)
     .then(parsed => {
       const savePromises = parsed.map(async p => {
         const prevModel = await Model.findOne(


### PR DESCRIPTION
OK. Ended up on not using onError hook of express-restify-mongoose because I have all sorts of problems when using it, like an undefined key error on https://github.com/florianholzapfel/express-restify-mongoose/blob/master/src/errorHandler.js#L8 on `req.params.id` on POSTs, and the handler returning an HTML error page instead of JSON even though I did 
```
onError: (err, req, res, next) => {
  const statusCode = req.erm.statusCode // 400 or 404

  res.status(statusCode).json({
    message: err.message
  })
}
``` 
just like the documentation says. But setting res.status(400).json inside the preCreate and preUpdate hooks behave much better. So,
```
POST http://localhost:8001/api/v1/Model
Content-Type: application/json
Body
{
	"model_name": "HCM-BROD-9989.C08",
   "model_type":"3-D: Other (neurosphere)",
   "growth_rate":6,
   "split_ratio":"1:2",
   "gender": "male",
   "race":"White",
   "age_at_diagnosis":50,
   "age_at_sample_acquisition":56,
   "primary_site":"Brain",
   "tmn_stage":"T0M1N4",
   "neoadjuvant_therapy":"Yes, both radiation and pharmaceutical treatment",
   "chemotherapeutic_drugs":false,
   "disease_status":"Progression (no response to treatment)",
   "vital_status":"alive",
   "therapy":"targeted therapy (small molecule inhibitors and targeted antibodies)",
   "clinical_tumor_diagnosis":"breast cancer",
   "histological_type":"Metaplastic ductal carcinoma",
   "site_of_sample_acquisition":"right breast",
   "tumor_histological_grade":"well differentiated"
}
```
Creates the model, with the same dup key and validation errors as sync mongo, eg

```
{
    "error": {
        "validationErrors": [
            {
                "errors": [
                    "race must be one of the following values: american indian or alaskan native, asian, black or african american, native hawaiian or other pacific islander, white, not reported, unknown"
                ],
                "value": {
                    "clinical_tumor_diagnosis": "breast cancer",
                    "tumor_histological_grade": "well differentiated",
                    "site_of_sample_acquisition": "right breast",
                    "histological_type": "metaplastic ductal carcinoma",
                    "therapy": "targeted therapy (small molecule inhibitors and targeted antibodies)",
                    "vital_status": "alive",
                    "disease_status": "progression (no response to treatment)",
                    "chemotherapeutic_drugs": false,
                    "neoadjuvant_therapy": "yes, both radiation and pharmaceutical treatment",
                    "tmn_stage": "T0M1N4",
                    "primary_site": "brain",
                    "age_at_sample_acquisition": 56,
                    "age_at_diagnosis": 50,
                    "race": "martian",
                    "gender": "male",
                    "split_ratio": "1:2",
                    "growth_rate": 6,
                    "model_type": "3-d: other (neurosphere)",
                    "model_name": "HCM-BROD-9989.C09"
                }
            }
        ]
    }
}
```
Similarly, to update
```
PATCH http://localhost:8001/api/v1/Model/HCM-BROD-9989.C08
Body 
{
	"model_name": "HCM-BROD-9989.C09",
   "model_type":"3-D: Other (neurosphere)",
   "growth_rate":6,
   "split_ratio":"1:2",
   "gender": "male",
   "race":"white",
   "age_at_diagnosis":50,
   "age_at_sample_acquisition":56,
   "primary_site":"Brain",
   "tmn_stage":"T0M1N4",
   "neoadjuvant_therapy":"Yes, both radiation and pharmaceutical treatment",
   "chemotherapeutic_drugs":false,
   "disease_status":"Progression (no response to treatment)",
   "vital_status":"alive",
   "therapy":"targeted therapy (small molecule inhibitors and targeted antibodies)",
   "clinical_tumor_diagnosis":"breast cancer",
   "histological_type":"Metaplastic ductal carcinoma",
   "site_of_sample_acquisition":"right breast",
   "tumor_histological_grade":"well differentiated"
}
```
as expected, GET reads and DELETE deletes. 

Closes #140