### PR TITLE
:sparkles: 145 CR_D api for images

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -24,8 +24,9 @@
     "lodash": "^4.17.10",
     "method-override": "^2.3.10",
     "mongoose": "^5.1.3",
-    "morgan": "^1.9.0",
     "mongoose-elasticsearch-xp": "^5.4.1",
+    "morgan": "^1.9.0",
+    "multer": "^1.3.1",
     "yup": "^0.25.1"
   },
   "devDependencies": {

--- a/cms/src/index.js
+++ b/cms/src/index.js
@@ -3,20 +3,24 @@ import express from 'express';
 import { Server } from 'http';
 import cors from 'cors';
 import mongoose from 'mongoose';
-import Model from './schemas/model';
 import bodyParser from 'body-parser';
 import methodOverride from 'method-override';
 import restify from 'express-restify-mongoose';
 import morgan from 'morgan';
+
 import { data_sync_router, runYupValidators } from './routes/sync-data';
 import { publish_router } from './routes/publish';
+import { imagesRouter } from './routes/images';
+import Model from './schemas/model';
 
 const port = process.env.PORT || 8080;
 const app = express();
 const router = express.Router();
 
 // Connect to database
-mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost/test');
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/test', {
+  useNewUrlParser: true,
+});
 
 // configure server
 app.use(bodyParser.json());
@@ -44,6 +48,7 @@ restify.serve(router, Model, {
 
 app.use('/api/v1', data_sync_router);
 app.use('/api/v1/publish', publish_router);
+app.use('/api/v1/images', imagesRouter);
 app.use(router);
 
 // start app

--- a/cms/src/routes/images.js
+++ b/cms/src/routes/images.js
@@ -1,0 +1,85 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import multer from 'multer';
+import { Readable } from 'stream';
+
+export const imagesRouter = express.Router();
+
+const conn = mongoose.createConnection(
+  process.env.MONGODB_URI || 'mongodb://localhost:27017/test',
+  {
+    useNewUrlParser: true,
+  },
+);
+let bucket;
+conn.once('open', function() {
+  bucket = new mongoose.mongo.GridFSBucket(conn.db, { bucketName: 'images' });
+  console.log('GridFSBucket is ready for uploads');
+});
+
+imagesRouter.post('/', async (req, res) => {
+  const storage = multer.memoryStorage();
+  const upload = multer({ storage, limits: { fields: 1, files: 1, parts: 2 } });
+  upload.single('image')(req, res, err => {
+    if (err) {
+      return res.status(500).json({ error: 'upload request failed' });
+    }
+    const filename = req.body.filename;
+    const readableStream = new Readable();
+    readableStream.push(req.file.buffer);
+    readableStream.push(null); // push null to mark data end
+
+    let uploadStream = bucket.openUploadStream(filename);
+    readableStream.pipe(uploadStream);
+
+    uploadStream
+      .on('error', () => {
+        return res.status(500).json({ error: 'Error uploading file' });
+      })
+      .on('finish', () => {
+        return res.status(201).json({ id: uploadStream.id, filename });
+      });
+  });
+});
+
+imagesRouter.get('/:id', async (req, res) => {
+  try {
+    const ObjectId = mongoose.Types.ObjectId;
+    const imageId = new ObjectId(req.params.id);
+
+    res.set('accept-ranges', 'bytes');
+
+    bucket
+      .openDownloadStream(imageId)
+      .on('data', chunk => {
+        res.write(chunk);
+      })
+      .on('error', () => {
+        res.status(404).json({ error: `cant delete, file with id ${req.params.id} not found` });
+      })
+      .on('end', () => {
+        res.end();
+      });
+  } catch (err) {
+    return res.status(400).json({ error: 'invalid id' });
+  }
+});
+
+imagesRouter.delete('/:id', async (req, res) => {
+  const {
+    params: { id },
+  } = req;
+  try {
+    const ObjectId = mongoose.Types.ObjectId;
+    const imageId = new ObjectId(req.params.id);
+
+    try {
+      await bucket.delete(imageId);
+      res.status(200).json({ success: `image with id ${id} deleted` });
+    } catch (e) {
+      res.status(500).json({ error: `error removing image with id ${id}` });
+    }
+  } catch (err) {
+    return res.status(400).json({ error: `image with id ${id} not found` });
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1817,6 +1817,10 @@ apollo-utilities@^1.0.0, apollo-utilities@^1.0.1:
   dependencies:
     fast-json-stable-stringify "^2.0.0"
 
+append-field@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/append-field/-/append-field-0.1.0.tgz#6ddc58fa083c7bc545d3c5995b2830cc2366d44a"
+
 append-transform@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
@@ -2684,6 +2688,13 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+busboy@^0.2.11:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
+  dependencies:
+    dicer "0.2.5"
+    readable-stream "1.1.x"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -3117,7 +3128,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.0, concat-stream@^1.6.0:
+concat-stream@^1.5.0, concat-stream@^1.5.2, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -3793,6 +3804,13 @@ detect-port-alt@1.1.5:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+dicer@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
+  dependencies:
+    readable-stream "1.1.x"
+    streamsearch "0.1.2"
 
 diff@^3.2.0:
   version "3.5.0"
@@ -4940,6 +4958,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+flushwritable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/flushwritable/-/flushwritable-1.0.0.tgz#3e328d8fde412ad47e738e3be750b4d290043498"
+
 fn-name@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
@@ -5461,6 +5483,12 @@ graphql@^0.13.2:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
     iterall "^1.2.1"
+
+gridfs-stream@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/gridfs-stream/-/gridfs-stream-1.1.1.tgz#3dd3a100ec2021a181282f6eb46709636074df89"
+  dependencies:
+    flushwritable "^1.0.0"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -7682,6 +7710,19 @@ ms@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
+multer@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-1.3.1.tgz#c3fb3b35f50c7eefe873532f90d3dde02ce6e040"
+  dependencies:
+    append-field "^0.1.0"
+    busboy "^0.2.11"
+    concat-stream "^1.5.2"
+    mkdirp "^0.5.1"
+    object-assign "^3.0.0"
+    on-finished "^2.3.0"
+    type-is "^1.6.4"
+    xtend "^4.0.0"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -7969,6 +8010,10 @@ object-assign@4.1.1, object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+
 object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
@@ -8035,7 +8080,7 @@ omit-deep@^0.3.0:
     is-plain-object "^2.0.1"
     unset-value "^0.1.1"
 
-on-finished@~2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
@@ -9388,6 +9433,15 @@ readable-stream@1.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
@@ -10354,6 +10408,10 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
 
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -10842,7 +10900,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.15, type-is@~1.6.16:
+type-is@^1.6.4, type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   dependencies:


### PR DESCRIPTION
This adds /images endpoint to upload, read and delete images. Uses mongo GridFSbuckets which creates 2 collections,`images.chuncks` and `images.files` which stores metadata. Filename and image file is sent in one request using `Content-Type: multipart/form-data`

Upload:
```
curl -X POST \
  http://localhost:8001/images \
  -H 'cache-control: no-cache' \
  -H 'content-type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW' \
  -H 'postman-token: fcb8f299-b435-4f21-29f2-2ceb63f7c9d1' \
  -F filename=worried_cat \
  -F image=@fw9y2gaxmhc11.jpg
```

![image](https://user-images.githubusercontent.com/1314446/43344194-e8d98a9e-91b6-11e8-9663-ac5ca2746509.png)
response:
```
{
    "id": "5b5b7a34832031494ee8bace",
    "filename": "worried_cat"
}
```

Read
`GET http://localhost:8001/images/5b5b7a34832031494ee8bace `
Delete
`DELETE http://localhost:8001/images/5b5b7a34832031494ee8bace`