### PR TITLE
rename back file_name and file_type

### DIFF
--- a/cms/src/schemas/model.js
+++ b/cms/src/schemas/model.js
@@ -2,8 +2,9 @@ import mongoose from 'mongoose';
 import { modelStatus } from './constants';
 
 const FilesSchema = new mongoose.Schema({
-  name: { type: String, es_indexed: true },
-  type: { type: String, es_indexed: true },
+  id: { type: String, es_indexed: true },
+  file_name: { type: String, es_indexed: true },
+  file_type: { type: String, es_indexed: true },
   scale_bar_length: { type: String, es_indexed: true },
   magnification: { type: Number, es_indexed: true },
   passage_number: { type: Number, es_indexed: true },

--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -19,6 +19,7 @@ import VariantTables from 'components/VariantTables';
 import ExternalLink from 'components/ExternalLink';
 import ShareButton from 'components/ShareButton';
 import { SelectedModelsContext } from 'providers/SelectedModels';
+import config from 'components/admin/config';
 
 const HorizontalTable = ({
   fieldNames,
@@ -246,6 +247,7 @@ export default ({ modelName }) => (
                     >
                       <img
                         src={modelImages[0].file_name}
+                        src={`${config.urls.cmsBase}/images/${modelImages[0].id}`}
                         alt={`File name: ${modelImages[0].file_name}`}
                         css={`
                           display: block;
@@ -262,7 +264,7 @@ export default ({ modelName }) => (
                           padding: 20px;
                         `}
                       >
-                        <span className="image-caption">image description</span>
+                        <span className="image-caption">modelImages[0].file_type</span>
                       </div>
                     </Col>
                   </Col>

--- a/ui/src/components/admin/Model/ModelImages.js
+++ b/ui/src/components/admin/Model/ModelImages.js
@@ -26,21 +26,21 @@ const {
 const ImageMetaDataForm = ({ file, editing, setPreviewState, onMetaDataSave }) => (
   <Formik
     initialValues={{
-      name: file.name || '',
+      name: file.file_name || '',
       scale_bar_length: file.scale_bar_length || 0,
       magnification: file.magnification || 0,
       passage_number: file.passage_number || 0,
     }}
     onSubmit={values => {
-      onMetaDataSave({ fileId: file._id, metaData: values });
+      onMetaDataSave({ fileId: file.id, metaData: values });
       setPreviewState({ editing: !editing });
     }}
     render={({ handleSubmit }) => (
       <ModelForm>
         <ul>
           <li>
-            {!editing ? <b>{file.name}</b> : <b>File name:</b>}
-            {editing && <Field name="name" component={FormInput} />}
+            {!editing ? <b>{file.file_name}</b> : <b>File name:</b>}
+            {editing && <Field name="file_name" component={FormInput} />}
           </li>
           <li>
             Scale-bar length: {!editing && file.scale_bar_length}
@@ -82,8 +82,8 @@ const ImagePreview = ({ file, queuedForDelete, onDelete, onMetaDataSave }) => (
         `}
       >
         <img
-          src={file.preview ? file.preview : `${config.urls.cmsBase}/images/${file._id}`}
-          alt={`File: ${file.name}`}
+          src={file.preview ? file.preview : `${config.urls.cmsBase}/images/${file.id}`}
+          alt={`File: ${file.file_name}`}
           height="155"
           width="250"
         />
@@ -124,7 +124,7 @@ const ImagePreview = ({ file, queuedForDelete, onDelete, onMetaDataSave }) => (
               width: 32px;
               height: 32px;
             `}
-            onClick={() => onDelete(file._id)}
+            onClick={() => onDelete(file.id)}
           >
             {queuedForDelete ? (
               <PlusIcon
@@ -174,10 +174,11 @@ const ImagePreview = ({ file, queuedForDelete, onDelete, onMetaDataSave }) => (
 
 const ImageGallery = ({ acceptedFiles, toDeleteFiles, onDelete, onMetaDataSave }) => (
   <>
+    {console.log(acceptedFiles)}
     {acceptedFiles.map(file => (
       <ImagePreview
-        queuedForDelete={toDeleteFiles.map(({ _id }) => _id).includes(file._id)}
-        key={file._id}
+        queuedForDelete={toDeleteFiles.map(({ id }) => id).includes(file.id)}
+        key={file.id}
         file={file}
         onDelete={onDelete}
         onMetaDataSave={onMetaDataSave}
@@ -258,10 +259,7 @@ export default () => (
               justify-content: space-between;
             `}
           >
-            <div>
-              Upload images in jpeg, tiff, png or svg formats.
-              {!!files.length && ' Drag and drop images to reorder them within the gallery.'}
-            </div>
+            <div>Upload images in jpeg, tiff, png or svg formats.</div>
             {!!files.length && (
               <Pill
                 css={`
@@ -293,16 +291,16 @@ export default () => (
                 onMetaDataSave={({ fileId, metaData }) => {
                   saveForm({
                     values,
-                    images: files.map(f => (f._id === fileId ? { ...f, ...metaData } : f)),
+                    images: files.map(f => (f.id === fileId ? { ...f, ...metaData } : f)),
                   });
                 }}
                 onDelete={toDeleteFileId => {
-                  const toDeleteFile = files.find(f => f._id === toDeleteFileId);
+                  const toDeleteFile = files.find(f => f.id === toDeleteFileId);
                   console.log(toDeleteFile);
                   saveForm({
                     values,
                     images: [
-                      ...files.filter(f => f._id !== toDeleteFileId),
+                      ...files.filter(f => f.id !== toDeleteFileId),
                       {
                         ...toDeleteFile,
                         marked_for_deletion: !toDeleteFile.marked_for_deletion,

--- a/ui/src/components/admin/Model/ModelSingleController.js
+++ b/ui/src/components/admin/Model/ModelSingleController.js
@@ -205,7 +205,7 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
 
               const data = {
                 ...values,
-                files: uniqBy(images, image => image._id),
+                files: uniqBy(images, image => image.id),
                 status: computeModelStatus(values.status, 'save'),
               };
 
@@ -459,7 +459,10 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
               });
               if (response.status >= 200 && response.status < 300) {
                 window.URL.revokeObjectURL(file.preview);
-                return [...acc, { name: file.name, type: file.type, _id: response.data.id }];
+                return [
+                  ...acc,
+                  { file_name: file.name, file_type: file.type, id: response.data.id },
+                ];
               }
               return acc;
             }, Promise.resolve([]));

--- a/ui/src/components/queries/ModelQuery.js
+++ b/ui/src/components/queries/ModelQuery.js
@@ -36,6 +36,7 @@ const fetchData = async ({ setState, modelName }) => {
                         hits{
                           edges {
                             node {
+                              id
                               file_name
                               file_type
                             }


### PR DESCRIPTION
i admit the err of my ways and renamed file.file_name and file.file_type so we don't have to update the mappings, except add an "id" field to files. Still haven't seen the images in there yet because my arranger decided to break again...but it should work (maybe).