### PR TITLE
CMS no longer requires age at diagnosis

### DIFF
--- a/cms/src/validation/model.js
+++ b/cms/src/validation/model.js
@@ -75,7 +75,6 @@ export default object().shape({
     .nullable(true)
     .oneOf(race),
   age_at_diagnosis: number()
-    .required('This is a required field')
     .integer()
     .transform(numberEmptyValueTransform)
     .min(0)


### PR DESCRIPTION
Only mandatory due to form validation, no model schema enforcement.