### PR TITLE
🐛 Update spelling and word choice for new fields

### DIFF
--- a/cms/src/schemas/constants.js
+++ b/cms/src/schemas/constants.js
@@ -1208,4 +1208,4 @@ export const variantExpressionLevel = [
   'No evidence of MMR alteration',
 ];
 
-export const tissueTypes = ['Primary', 'Metastasis', 'Recurrent', 'Pre-malignan'];
+export const tissueTypes = ['Primary', 'Metastasis', 'Recurrent', 'Pre-malignant'];

--- a/cms/src/schemas/descriptions/model.js
+++ b/cms/src/schemas/descriptions/model.js
@@ -113,7 +113,7 @@ export const schemaArr = [
         ? `Yes`
         : `No`,
   },
-  { displayName: 'Distributor Part Number', accessor: 'distributor_part_number' },
+  { displayName: 'Link to Distributor', accessor: 'distributor_part_number' },
   {
     displayName: 'Model URL',
     accessor: 'source_model_url',

--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -136,6 +136,7 @@ export default ({ modelName }) => (
                         if (val === 'N/A') {
                           return val;
                         }
+                        // Val will be formatted as localeString (with commas) so we need to remove those before doing math
                         const hours = val;
                         const numericHours = parseInt(val.replace(/,/g, ''));
                         const days = Math.round((numericHours / 24) * 100) / 100;

--- a/ui/src/components/admin/Model/ModelForm.js
+++ b/ui/src/components/admin/Model/ModelForm.js
@@ -365,11 +365,14 @@ const ModelFormTemplate = ({ values, touched, dirty, errors, setTouched }) => (
                 description="Please provide urls to GDC or EGA"
               />
 
-              <FormComponent labelText={distributor_part_number.displayName}>
+              <FormComponent
+                labelText="Distributor ID"
+                description="Please provide the ATCC ID, e.g. PDM-146"
+              >
                 <Field
                   name={distributor_part_number.accessor}
                   component={FormInput}
-                  placeholder="PMD-123"
+                  placeholder="PMD-146"
                 />
               </FormComponent>
               <a href={`https://www.atcc.org/products/all/${values[distributor_part_number]}`}>


### PR DESCRIPTION
- `Link to Distributor` instead of Distributor Part Number
- Update CMS description for Distributor ID
- typo in Tissue type value `Pre-malignant`
