### PR TITLE
🐛 Fix "Expand All" button & filter Editable Fields list (#591)

### DIFF
--- a/ui/src/components/admin/DataDictionary/DependentFieldValuesGroup.js
+++ b/ui/src/components/admin/DataDictionary/DependentFieldValuesGroup.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { useDictionary } from './DictionaryController';
 import EditableFieldValue from './EditableFieldValue';

--- a/ui/src/components/admin/DataDictionary/DependentFieldValuesGroup.js
+++ b/ui/src/components/admin/DataDictionary/DependentFieldValuesGroup.js
@@ -15,9 +15,14 @@ import {
 } from 'theme/adminDictionaryStyles';
 import { Row } from 'theme/system';
 
-const DependentFieldValuesGroup = ({ fieldName, fieldKey, fieldValues, isOpen = false }) => {
+const DependentFieldValuesGroup = ({
+  expanded,
+  fieldName,
+  fieldKey,
+  fieldValues,
+  toggleHandler,
+}) => {
   const { addDependentField, editDependentField, removeDependentField } = useDictionary();
-  const [expanded, setExpanded] = useState(isOpen);
   const [newFieldValue, setNewFieldValue] = useState('');
 
   const addField = (e, fieldName, fieldType) => {
@@ -36,13 +41,9 @@ const DependentFieldValuesGroup = ({ fieldName, fieldKey, fieldValues, isOpen = 
     removeDependentField(fieldName, fieldType);
   };
 
-  useEffect(() => {
-    setExpanded(isOpen);
-  }, [isOpen]);
-
   return (
     <>
-      <DependentFieldType onClick={() => setExpanded(!expanded)}>
+      <DependentFieldType onClick={toggleHandler}>
         <AdminDictionaryArrowIcon
           height={12}
           width={12}

--- a/ui/src/components/admin/DataDictionary/DictionaryDependentFieldValues.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryDependentFieldValues.js
@@ -22,6 +22,7 @@ const DictionaryDependentFieldValues = () => {
     [DEPENDENT_FIELD_KEYS.siteOfSampleAcquisition]: false,
     [DEPENDENT_FIELD_KEYS.tumorHistologicalGrade]: false,
   });
+  const [shouldExpand, setShouldExpand] = useState(true);
 
   const expandAll = e => {
     e.preventDefault();
@@ -31,7 +32,25 @@ const DictionaryDependentFieldValues = () => {
       [DEPENDENT_FIELD_KEYS.siteOfSampleAcquisition]: true,
       [DEPENDENT_FIELD_KEYS.tumorHistologicalGrade]: true,
     });
-    console.log('Data Dictionary: Expand All');
+    setShouldExpand(false);
+  };
+
+  const collapseAll = e => {
+    e.preventDefault();
+    setExpanded({
+      [DEPENDENT_FIELD_KEYS.histologicalType]: false,
+      [DEPENDENT_FIELD_KEYS.clinicalStageGrouping]: false,
+      [DEPENDENT_FIELD_KEYS.siteOfSampleAcquisition]: false,
+      [DEPENDENT_FIELD_KEYS.tumorHistologicalGrade]: false,
+    });
+    setShouldExpand(true);
+  };
+
+  const toggleExpanded = key => {
+    setExpanded({
+      ...expanded,
+      [key]: !expanded[key],
+    });
   };
 
   const getDependents = dependentKey => {
@@ -56,34 +75,38 @@ const DictionaryDependentFieldValues = () => {
       <DependentValues>
         <DependentValuesHeader>
           <DictionaryColumnHeading>Dependent Field Values</DictionaryColumnHeading>
-          <HoverPill primary css={expandPill} onClick={expandAll}>
-            Expand All
+          <HoverPill primary css={expandPill} onClick={shouldExpand ? expandAll : collapseAll}>
+            {shouldExpand ? 'Expand All' : 'Collapse All'}
           </HoverPill>
         </DependentValuesHeader>
 
         <DependentFieldValuesGroup
+          expanded={expanded[DEPENDENT_FIELD_KEYS.histologicalType]}
           fieldName={'Histological Subtype'}
           fieldKey={DEPENDENT_FIELD_KEYS.histologicalType}
           fieldValues={getDependents(DEPENDENT_FIELD_KEYS.histologicalType)}
-          isOpen={expanded[DEPENDENT_FIELD_KEYS.histologicalType]}
+          toggleHandler={() => toggleExpanded(DEPENDENT_FIELD_KEYS.histologicalType)}
         />
         <DependentFieldValuesGroup
+          expanded={expanded[DEPENDENT_FIELD_KEYS.clinicalStageGrouping]}
           fieldName={'Clinical Stage Grouping'}
           fieldKey={DEPENDENT_FIELD_KEYS.clinicalStageGrouping}
           fieldValues={getDependents(DEPENDENT_FIELD_KEYS.clinicalStageGrouping)}
-          isOpen={expanded[DEPENDENT_FIELD_KEYS.clinicalStageGrouping]}
+          toggleHandler={() => toggleExpanded(DEPENDENT_FIELD_KEYS.clinicalStageGrouping)}
         />
         <DependentFieldValuesGroup
+          expanded={expanded[DEPENDENT_FIELD_KEYS.tumorHistologicalGrade]}
           fieldName={'Histological Grade'}
           fieldKey={DEPENDENT_FIELD_KEYS.tumorHistologicalGrade}
           fieldValues={getDependents(DEPENDENT_FIELD_KEYS.tumorHistologicalGrade)}
-          isOpen={expanded[DEPENDENT_FIELD_KEYS.tumorHistologicalGrade]}
+          toggleHandler={() => toggleExpanded(DEPENDENT_FIELD_KEYS.tumorHistologicalGrade)}
         />
         <DependentFieldValuesGroup
+          expanded={expanded[DEPENDENT_FIELD_KEYS.siteOfSampleAcquisition]}
           fieldName={'Acquisition Site'}
           fieldKey={DEPENDENT_FIELD_KEYS.siteOfSampleAcquisition}
           fieldValues={getDependents(DEPENDENT_FIELD_KEYS.siteOfSampleAcquisition)}
-          isOpen={expanded[DEPENDENT_FIELD_KEYS.siteOfSampleAcquisition]}
+          toggleHandler={() => toggleExpanded(DEPENDENT_FIELD_KEYS.siteOfSampleAcquisition)}
         />
       </DependentValues>
     )

--- a/ui/src/components/admin/DataDictionary/DictionarySidebar.js
+++ b/ui/src/components/admin/DataDictionary/DictionarySidebar.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 
 import { useDictionary } from './DictionaryController';
+import { EDITABLE_FIELDS } from './../helpers/dictionary';
 
 import TabGroup from 'components/layout/VerticalTabs';
 import Tab from 'components/layout/VerticalTabs/Tab';
@@ -32,6 +33,7 @@ const DictionarySidebar = ({ width }) => {
       {dictionary &&
         dictionary.fields &&
         dictionary.fields
+          .filter(field => EDITABLE_FIELDS.indexOf(field.name) > -1)
           .sort((a, b) => {
             if (a.displayName.toLowerCase() < b.displayName.toLowerCase()) return -1;
             if (a.displayName.toLowerCase() > b.displayName.toLowerCase()) return 1;

--- a/ui/src/components/admin/helpers/dictionary.js
+++ b/ui/src/components/admin/helpers/dictionary.js
@@ -100,6 +100,19 @@ export const DEPENDENT_FIELD_KEYS = {
   tumorHistologicalGrade: 'tumor histological grade',
 };
 
+export const EDITABLE_FIELDS = [
+  'clinicalTumorDiagnosis',
+  'diseaseStatus',
+  'gender',
+  'modelType',
+  'neoadjuvantTherapy',
+  'primarySites',
+  'race',
+  'therapy',
+  'tissueTypes',
+  'vitalStatus',
+];
+
 export const emptyDictionary = {
   clinicalTumorDiagnosisDependent: {},
   clinicalTumorDiagnosisOptions: [],


### PR DESCRIPTION
- 🐛 Fix the "Expand All" button, make it toggle to a "Collapse All" button as well
- 🐛 Filter the "Editable Fields" list against a list of fields that are actually editable