### PR TITLE
🐛 Bug Fixes for #551 #555 and #556

### DIFF
--- a/cms/src/schemas/descriptions/model.js
+++ b/cms/src/schemas/descriptions/model.js
@@ -10,7 +10,7 @@ export const schemaArr = [
     accessor: 'expanded',
   },
   {
-    displayName: 'Type',
+    displayName: 'Model Type',
     accessor: 'type',
   },
   {

--- a/ui/src/components/admin/DataDictionary/DependentFieldValuesGroup.js
+++ b/ui/src/components/admin/DataDictionary/DependentFieldValuesGroup.js
@@ -22,23 +22,23 @@ const DependentFieldValuesGroup = ({
   fieldValues,
   toggleHandler,
 }) => {
-  const { addDependentField, editDependentField, removeDependentField } = useDictionary();
+  const { addField, editField, removeField } = useDictionary();
   const [newFieldValue, setNewFieldValue] = useState('');
 
-  const addField = (e, fieldName, fieldType) => {
+  const add = (e, fieldName, fieldType) => {
     e.preventDefault();
 
-    addDependentField(fieldName.trim(), fieldType);
+    addField(fieldName.trim(), fieldType);
 
     setNewFieldValue('');
   };
 
-  const editField = (originalValue, updatedValue, fieldType) => {
-    editDependentField(originalValue, updatedValue, fieldType);
+  const edit = (originalValue, updatedValue, fieldType) => {
+    editField(originalValue, updatedValue, fieldType);
   };
 
-  const removeField = (fieldName, fieldType) => {
-    removeDependentField(fieldName, fieldType);
+  const remove = (fieldName, fieldType) => {
+    removeField(fieldName, fieldType);
   };
 
   return (
@@ -54,7 +54,7 @@ const DependentFieldValuesGroup = ({
       {expanded && (
         <>
           <Row>
-            <AddFieldForm onSubmit={e => addField(e, newFieldValue, fieldKey)}>
+            <AddFieldForm onSubmit={e => add(e, newFieldValue, fieldKey)}>
               <AddFieldInput
                 type="text"
                 id="new-field"
@@ -80,9 +80,9 @@ const DependentFieldValuesGroup = ({
                   initialValue={x.value}
                   initialState={x.status}
                   original={x.original}
-                  editFn={updatedValue => editField(x.value, updatedValue, fieldKey)}
-                  removeFn={() => removeField(x.value, fieldKey)}
-                  resetFn={() => editField(x.original, x.original, fieldKey)}
+                  editFn={updatedValue => edit(x.value, updatedValue, fieldKey)}
+                  removeFn={() => remove(x.value, fieldKey)}
+                  resetFn={() => edit(x.original, x.original, fieldKey)}
                 />
               ))}
             </FieldValueList>

--- a/ui/src/components/admin/DataDictionary/DependentFieldValuesGroup.js
+++ b/ui/src/components/admin/DataDictionary/DependentFieldValuesGroup.js
@@ -80,7 +80,7 @@ const DependentFieldValuesGroup = ({
                   initialValue={x.value}
                   initialState={x.status}
                   original={x.original}
-                  editFn={updatedValue => edit(x.value, updatedValue, fieldKey)}
+                  editFn={updatedValue => edit(x.original || x.value, updatedValue, fieldKey)}
                   removeFn={() => remove(x.value, fieldKey)}
                   resetFn={() => edit(x.original, x.original, fieldKey)}
                 />

--- a/ui/src/components/admin/DataDictionary/DictionaryController.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryController.js
@@ -21,6 +21,7 @@ export const DictionaryProvider = props => {
     activeFieldValues: [],
     activeValue: '',
     activeValueDependents: [],
+    activeValueOriginal: '',
     totalEdits: 0,
     totalNew: 0,
     lastPublished: '',
@@ -48,21 +49,23 @@ export const useDictionary = () => {
       activeField: fieldName,
       activeFieldSlug: fieldSlug,
       activeValue: '',
+      activeValueOriginal: '',
     });
   };
 
-  const setActiveValue = (valueName, valueDependents) => {
+  const setActiveValue = (valueName, valueDependents, valueOriginal) => {
     setState({
       ...state,
       activeValue: valueName,
       activeValueDependents: valueDependents,
+      activeValueOriginal: valueOriginal,
     });
   };
 
   const addField = (fieldName, fieldType = null) => {
     addDictionaryDraftValue({
       field: state.activeFieldSlug,
-      parent: fieldType ? state.activeValue : null,
+      parent: fieldType ? state.activeValueOriginal || state.activeValue : null,
       dependentName: fieldType,
       value: fieldName,
     }).then(response => {
@@ -85,7 +88,7 @@ export const useDictionary = () => {
   const editField = (original, updated, fieldType = null) => {
     editDictionaryDraftValue({
       field: state.activeFieldSlug,
-      parent: fieldType ? state.activeValue : null,
+      parent: fieldType ? state.activeValueOriginal || state.activeValue : null,
       dependentName: fieldType,
       original,
       updated,
@@ -109,7 +112,7 @@ export const useDictionary = () => {
   const removeField = (fieldName, fieldType = null) => {
     removeDictionaryDraftValue({
       field: state.activeFieldSlug,
-      parent: fieldType ? state.activeValue : null,
+      parent: fieldType ? state.activeValueOriginal || state.activeValue : null,
       dependentName: fieldType,
       value: fieldName,
     }).then(response => {

--- a/ui/src/components/admin/DataDictionary/DictionaryController.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryController.js
@@ -1,6 +1,8 @@
 import React, { useState, useContext } from 'react';
 import moment from 'moment-timezone';
 
+import { NotificationsContext } from './../Notifications';
+
 import {
   addDictionaryDraftValue,
   deleteDictionaryDraft,
@@ -32,8 +34,13 @@ export const DictionaryProvider = props => {
   );
 };
 
+const getDictionaryErrorMessage = res => {
+  return res.err ? res.err : 'Unknown error has occurred.';
+};
+
 export const useDictionary = () => {
   const [state, setState] = useContext(DictionaryContext);
+  const { appendNotification } = useContext(NotificationsContext);
 
   const setActiveField = (fieldName, fieldSlug) => {
     setState({
@@ -52,101 +59,115 @@ export const useDictionary = () => {
     });
   };
 
-  const addField = fieldName => {
+  const addField = (fieldName, fieldType = null) => {
     addDictionaryDraftValue({
       field: state.activeFieldSlug,
-      value: fieldName,
-    }).then(updatedDictionary => {
-      setState({
-        ...state,
-        dictionary: updatedDictionary,
-      });
-    });
-  };
-
-  const editField = (original, updated) => {
-    editDictionaryDraftValue({
-      field: state.activeFieldSlug,
-      original,
-      updated,
-    }).then(updatedDictionary => {
-      setState({
-        ...state,
-        dictionary: updatedDictionary,
-      });
-    });
-  };
-
-  const removeField = fieldName => {
-    removeDictionaryDraftValue({
-      field: state.activeFieldSlug,
-      value: fieldName,
-    }).then(updatedDictionary => {
-      setState({
-        ...state,
-        dictionary: updatedDictionary,
-      });
-    });
-  };
-
-  const addDependentField = (fieldName, fieldType) => {
-    addDictionaryDraftValue({
-      field: state.activeFieldSlug,
-      parent: state.activeValue,
+      parent: fieldType ? state.activeValue : null,
       dependentName: fieldType,
       value: fieldName,
-    }).then(updatedDictionary => {
-      setState({
-        ...state,
-        dictionary: updatedDictionary,
-      });
+    }).then(response => {
+      if (response.err) {
+        appendNotification({
+          type: 'error',
+          message: 'Add Dictionary Field Error.',
+          details: getDictionaryErrorMessage(response),
+          timeout: false,
+        });
+      } else {
+        setState({
+          ...state,
+          dictionary: response,
+        });
+      }
     });
   };
 
-  const editDependentField = (original, updated, fieldType) => {
+  const editField = (original, updated, fieldType = null) => {
     editDictionaryDraftValue({
       field: state.activeFieldSlug,
-      parent: state.activeValue,
+      parent: fieldType ? state.activeValue : null,
       dependentName: fieldType,
       original,
       updated,
-    }).then(updatedDictionary => {
-      setState({
-        ...state,
-        dictionary: updatedDictionary,
-      });
+    }).then(response => {
+      if (response.err) {
+        appendNotification({
+          type: 'error',
+          message: 'Edit Dictionary Field Error.',
+          details: getDictionaryErrorMessage(response),
+          timeout: false,
+        });
+      } else {
+        setState({
+          ...state,
+          dictionary: response,
+        });
+      }
     });
   };
 
-  const removeDependentField = (fieldName, fieldType) => {
+  const removeField = (fieldName, fieldType = null) => {
     removeDictionaryDraftValue({
       field: state.activeFieldSlug,
-      parent: state.activeValue,
+      parent: fieldType ? state.activeValue : null,
       dependentName: fieldType,
       value: fieldName,
-    }).then(updatedDictionary => {
-      setState({
-        ...state,
-        dictionary: updatedDictionary,
-      });
+    }).then(response => {
+      if (response.err) {
+        appendNotification({
+          type: 'error',
+          message: 'Remove Dictionary Field Error.',
+          details: getDictionaryErrorMessage(response),
+          timeout: false,
+        });
+      } else {
+        setState({
+          ...state,
+          dictionary: response,
+        });
+      }
     });
   };
 
   const reset = () => {
-    deleteDictionaryDraft().then(updatedDictionary => {
-      setState({
-        ...state,
-        dictionary: updatedDictionary,
-      });
+    deleteDictionaryDraft().then(response => {
+      if (response.err) {
+        appendNotification({
+          type: 'error',
+          message: 'Reset Dictionary Draft Error.',
+          details: getDictionaryErrorMessage(response),
+          timeout: false,
+        });
+      } else {
+        setState({
+          ...state,
+          dictionary: response,
+        });
+      }
     });
   };
 
   const publish = () => {
-    publishDictionaryDraft().then(updatedDictionary => {
-      setState({
-        ...state,
-        dictionary: updatedDictionary,
-      });
+    publishDictionaryDraft().then(response => {
+      if (response.err) {
+        appendNotification({
+          type: 'error',
+          message: 'Publish Dictionary Draft Error.',
+          details: getDictionaryErrorMessage(response),
+          timeout: false,
+        });
+      } else {
+        setState({
+          ...state,
+          dictionary: response,
+        });
+        appendNotification({
+          type: 'success',
+          message: `The data dictionary updates have been published and applied to ${
+            response.updatedModels
+          } model${response.updatedModels !== 1 ? 's' : ''}.`,
+        });
+      }
     });
   };
 
@@ -243,9 +264,6 @@ export const useDictionary = () => {
     addField,
     editField,
     removeField,
-    addDependentField,
-    editDependentField,
-    removeDependentField,
     reset,
     publish,
   };

--- a/ui/src/components/admin/DataDictionary/DictionaryFieldValues.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryFieldValues.js
@@ -86,7 +86,9 @@ const DictionaryFieldValues = () => {
                         }
                       : null
                   }
-                  editFn={updatedValue => editNewField(fieldValue.value, updatedValue)}
+                  editFn={updatedValue =>
+                    editNewField(fieldValue.original || fieldValue.value, updatedValue)
+                  }
                   removeFn={() => removeNewField(fieldValue.value)}
                   resetFn={() => editNewField(fieldValue.original, fieldValue.original)}
                 />

--- a/ui/src/components/admin/DataDictionary/DictionaryFieldValues.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryFieldValues.js
@@ -82,7 +82,11 @@ const DictionaryFieldValues = () => {
                   clickHandler={
                     activeField === CLINICAL_TUMOR_DIAGNOSIS
                       ? () => {
-                          setActiveValue(fieldValue.value, fieldValue.dependents);
+                          setActiveValue(
+                            fieldValue.value,
+                            fieldValue.dependents,
+                            fieldValue.original,
+                          );
                         }
                       : null
                   }

--- a/ui/src/components/admin/DataDictionary/DictionaryHeader.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryHeader.js
@@ -8,8 +8,8 @@ import { HoverPill } from 'theme/adminControlsStyles';
 import { AdminHeader, AdminHeaderBlock } from 'theme/adminStyles';
 import {
   DataDictionaryH1,
-  DictionaryDraftPublished,
-  DictionaryDraftUpdated,
+  DictionaryDraftTimestamp,
+  DictionaryDraftStats,
   HeaderPill,
   actionPill,
   cancelPill,
@@ -34,18 +34,24 @@ const DictionaryHeader = () => {
       <NotificationToaster />
       <AdminHeader>
         <AdminHeaderBlock>
-          <DictionaryDraftPublished>Last published: {lastPublished}</DictionaryDraftPublished>
+          <DictionaryDraftTimestamp>
+            Last published: {lastPublished}
+            {isDraft && (
+              <>
+                <br />
+                Last updated: {lastUpdated}
+              </>
+            )}
+          </DictionaryDraftTimestamp>
           <DataDictionaryH1>Data Dictionary</DataDictionaryH1>
           {isDraft && (
             <>
               <HeaderPill>Draft</HeaderPill>
-              <DictionaryDraftUpdated>
-                Last updated: {lastUpdated}
-                <span>|</span>
+              <DictionaryDraftStats>
                 {totalEdits} edited value{totalEdits !== 1 ? 's' : ''}
                 <span>|</span>
                 {totalNew} new value{totalNew !== 1 ? 's' : ''}
-              </DictionaryDraftUpdated>
+              </DictionaryDraftStats>
             </>
           )}
         </AdminHeaderBlock>

--- a/ui/src/components/admin/DataDictionary/DictionaryHeader.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryHeader.js
@@ -5,8 +5,9 @@ import { NotificationToaster } from './../Notifications';
 import useConfirmationModal from './../../modals/ConfirmationModal';
 
 import { HoverPill } from 'theme/adminControlsStyles';
-import { AdminHeader, AdminHeaderBlock } from 'theme/adminStyles';
+import { AdminHeaderBlock } from 'theme/adminStyles';
 import {
+  DataDictionaryHeader,
   DataDictionaryH1,
   DictionaryDraftTimestamp,
   DictionaryDraftStats,
@@ -32,7 +33,7 @@ const DictionaryHeader = () => {
   return (
     <>
       <NotificationToaster />
-      <AdminHeader>
+      <DataDictionaryHeader>
         <AdminHeaderBlock>
           <DictionaryDraftTimestamp>
             Last published: {lastPublished}
@@ -90,7 +91,7 @@ const DictionaryHeader = () => {
             </HoverPill>,
           )}
         </AdminHeaderBlock>
-      </AdminHeader>
+      </DataDictionaryHeader>
     </>
   );
 };

--- a/ui/src/components/admin/DataDictionary/DictionarySidebar.js
+++ b/ui/src/components/admin/DataDictionary/DictionarySidebar.js
@@ -12,7 +12,7 @@ const DictionarySidebar = ({ width }) => {
 
   const generateStatsString = field => {
     return field && field.stats
-      ? `${field.stats.edited || 0} edit | ${field.stats.new || 0} new`
+      ? `${field.stats.edited || 0} edited | ${field.stats.new || 0} new`
       : null;
   };
 

--- a/ui/src/components/admin/DataDictionary/EditableFieldValue.js
+++ b/ui/src/components/admin/DataDictionary/EditableFieldValue.js
@@ -90,6 +90,14 @@ const EditableFieldValue = ({
     }
   }, [fieldState]);
 
+  useEffect(() => {
+    setFieldState(initialState);
+  }, [initialState]);
+
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
   const renderFieldLabel = fieldState => {
     switch (fieldState) {
       case 'editing':

--- a/ui/src/components/admin/helpers/dictionary.js
+++ b/ui/src/components/admin/helpers/dictionary.js
@@ -108,6 +108,7 @@ export const EDITABLE_FIELDS = [
   'neoadjuvantTherapy',
   'primarySites',
   'race',
+  'splitRatio',
   'therapy',
   'tissueTypes',
   'vitalStatus',

--- a/ui/src/components/admin/helpers/dictionary.js
+++ b/ui/src/components/admin/helpers/dictionary.js
@@ -13,21 +13,42 @@ export const getDictionary = async () => {
 
 export const getDictionaryDraft = async () => {
   const url = DICTIONARY_DRAFT_URL;
-  const response = await get({ url });
+  const response = await get({ url })
+    .then(res => {
+      return res;
+    })
+    .catch(err => {
+      return err.response;
+    });
+
   const dictionary = response.data;
   return dictionary;
 };
 
 export const deleteDictionaryDraft = async () => {
   const url = DICTIONARY_DRAFT_URL;
-  const response = await fetchData({ url, method: 'delete', data: '' });
+  const response = await fetchData({ url, method: 'delete', data: '' })
+    .then(res => {
+      return res;
+    })
+    .catch(err => {
+      return err.response;
+    });
+
   const dictionary = response.data;
   return dictionary;
 };
 
 export const publishDictionaryDraft = async () => {
   const url = `${DICTIONARY_DRAFT_URL}/publish`;
-  const response = await post({ url, data: '' });
+  const response = await post({ url, data: '' })
+    .then(res => {
+      return res;
+    })
+    .catch(err => {
+      return err.response;
+    });
+
   const dictionary = response.data;
   return dictionary;
 };
@@ -45,8 +66,14 @@ export const addDictionaryDraftValue = async ({
     dependentName,
     value,
   };
-  const response = await post({ url, data });
-  // TODO: error handling from API
+  const response = await post({ url, data })
+    .then(res => {
+      return res;
+    })
+    .catch(err => {
+      return err.response;
+    });
+
   const dictionary = response.data;
   return dictionary;
 };
@@ -66,8 +93,14 @@ export const editDictionaryDraftValue = async ({
     original,
     updated,
   };
-  const response = await patch({ url, data });
-  // TODO: error handling from API
+  const response = await patch({ url, data })
+    .then(res => {
+      return res;
+    })
+    .catch(err => {
+      return err.response;
+    });
+
   const dictionary = response.data;
   return dictionary;
 };
@@ -85,8 +118,14 @@ export const removeDictionaryDraftValue = async ({
     dependentName,
     value,
   };
-  const response = await post({ url, data });
-  // TODO: error handling from API
+  const response = await post({ url, data })
+    .then(res => {
+      return res;
+    })
+    .catch(err => {
+      return err.response;
+    });
+
   const dictionary = response.data;
   return dictionary;
 };

--- a/ui/src/theme/adminDictionaryStyles.js
+++ b/ui/src/theme/adminDictionaryStyles.js
@@ -50,18 +50,18 @@ export const HeaderPill = styled('span')`
   margin: auto 10px;
 `;
 
-export const DictionaryDraftPublished = styled('span')`
+export const DictionaryDraftTimestamp = styled('span')`
   font-size: 11px;
   font-weight: normal;
   font-stretch: normal;
   font-style: normal;
-  line-height: 1.27;
+  line-height: 1.5;
   position: absolute;
-  top: 20px;
+  top: 18px;
   padding-left: 2px;
 `;
 
-export const DictionaryDraftUpdated = styled('span')`
+export const DictionaryDraftStats = styled('span')`
   font-size: 12px;
   font-weight: normal;
   font-stretch: normal;

--- a/ui/src/theme/adminDictionaryStyles.js
+++ b/ui/src/theme/adminDictionaryStyles.js
@@ -2,7 +2,7 @@ import { css } from 'emotion';
 import styled from 'react-emotion';
 import base from 'theme';
 
-import { AdminContent, AdminHeaderH1 } from 'theme/adminStyles';
+import { AdminContent, AdminHeader, AdminHeaderH1 } from 'theme/adminStyles';
 import { Col } from 'theme/system';
 import { Row } from 'theme/system';
 
@@ -26,6 +26,10 @@ const {
 } = base;
 
 const borderColour = porcelain;
+
+export const DataDictionaryHeader = styled(AdminHeader)`
+  position: relative;
+`;
 
 export const DataDictionaryH1 = styled(AdminHeaderH1)`
   font-size: 26px;
@@ -51,14 +55,17 @@ export const HeaderPill = styled('span')`
 `;
 
 export const DictionaryDraftTimestamp = styled('span')`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  padding-left: 2px;
+  height: 40px;
   font-size: 11px;
   font-weight: normal;
   font-stretch: normal;
   font-style: normal;
   line-height: 1.5;
-  position: absolute;
-  top: 18px;
-  padding-left: 2px;
 `;
 
 export const DictionaryDraftStats = styled('span')`

--- a/ui/src/theme/adminModalStyles.js
+++ b/ui/src/theme/adminModalStyles.js
@@ -74,6 +74,7 @@ const closeStyles = css`
   top: 18px;
   right: 20px;
   margin: 0;
+  cursor: pointer;
 `;
 
 export const CloseModal = props => (


### PR DESCRIPTION
Fixed bugs for #551 #555 and #556 :
- Set `cursor: pointer` on modal close icon
- Re-add the "Split Ratio" field
- Add error handling to Editable Dictionary and show success notification/toast on publish
- Fix bug where Editable Fields weren't updating state/value after Draft Publish/Reset
- Fix bug preventing multiple edits of the same Editable Field per draft
- Fix bug preventing multiple edits of the same dependent field in one draft

Also made some front-end changes based on feedback:
- Change grammar on "edited" text in sidebar to match the header
- Change Model Details "Type" label to "Model Type" for consistency
- Move "Last updated" timestamp below "Last published" timestamp in header

Also refactored the "add", "edit", and "remove" functionality to use the same function for both regular and dependent fields, instead of having separate "___Field" and "____DependentField" functions since it's the same API endpoint for each.