### PR TITLE
🐛+💄 Bug fixes and improvements for #609

### DIFF
--- a/ui/src/components/FormComponents.js
+++ b/ui/src/components/FormComponents.js
@@ -29,11 +29,13 @@ const normalizeOption = option => (option === 'true' ? true : option === 'false'
 
 // Map simple string/number options to keyed objects
 const processOptions = options =>
-  options.map(option =>
-    typeof option === 'object' && option.constructor === Object
-      ? option
-      : { label: option, value: normalizeOption(option) },
-  );
+  options
+    .sort()
+    .map(option =>
+      typeof option === 'object' && option.constructor === Object
+        ? option
+        : { label: option, value: normalizeOption(option) },
+    );
 
 export const FormComponent = ({
   children,

--- a/ui/src/components/admin/DataDictionary/DataDictionary.js
+++ b/ui/src/components/admin/DataDictionary/DataDictionary.js
@@ -8,8 +8,7 @@ import DictionaryDependentFieldValues from './DictionaryDependentFieldValues';
 
 import { getDictionaryDraft } from './../helpers/dictionary';
 
-import { AdminContainer } from 'theme/adminStyles';
-import { AdminDictionaryContent } from 'theme/adminDictionaryStyles';
+import { AdminDictionaryContent, DictionaryContainer } from 'theme/adminDictionaryStyles';
 import { Row } from 'theme/system';
 
 const mainTabWidth = 280;
@@ -27,7 +26,7 @@ const DataDictionary = () => {
   }, []);
 
   return (
-    <AdminContainer>
+    <DictionaryContainer>
       <DictionaryHeader />
       <Row>
         <DictionarySidebar width={mainTabWidth} />
@@ -36,7 +35,7 @@ const DataDictionary = () => {
           <DictionaryDependentFieldValues />
         </AdminDictionaryContent>
       </Row>
-    </AdminContainer>
+    </DictionaryContainer>
   );
 };
 

--- a/ui/src/components/admin/DataDictionary/DictionaryController.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryController.js
@@ -154,6 +154,9 @@ export const useDictionary = () => {
         setState({
           ...state,
           dictionary: response,
+          activeValue: '',
+          activeValueDependents: [],
+          activeValueOriginal: '',
         });
       }
     });

--- a/ui/src/components/admin/DataDictionary/DictionaryController.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryController.js
@@ -85,7 +85,7 @@ export const useDictionary = () => {
     });
   };
 
-  const editField = (original, updated, fieldType = null) => {
+  const editField = (original, updated, fieldType = null, isParent = false) => {
     editDictionaryDraftValue({
       field: state.activeFieldSlug,
       parent: fieldType ? state.activeValueOriginal || state.activeValue : null,
@@ -101,10 +101,19 @@ export const useDictionary = () => {
           timeout: false,
         });
       } else {
-        setState({
-          ...state,
-          dictionary: response,
-        });
+        if (isParent) {
+          setState({
+            ...state,
+            dictionary: response,
+            activeValue: updated,
+            activeValueOriginal: original,
+          });
+        } else {
+          setState({
+            ...state,
+            dictionary: response,
+          });
+        }
       }
     });
   };

--- a/ui/src/components/admin/DataDictionary/DictionaryDependentFieldValues.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryDependentFieldValues.js
@@ -71,10 +71,13 @@ const DictionaryDependentFieldValues = () => {
 
   return (
     activeField === CLINICAL_TUMOR_DIAGNOSIS &&
-    activeValue && (
+    activeValue &&
+    activeValueDependents && (
       <DependentValues>
         <DependentValuesHeader>
-          <DictionaryColumnHeading>Dependent Field Values</DictionaryColumnHeading>
+          <DictionaryColumnHeading>
+            Dependent Field Values for {activeValue}
+          </DictionaryColumnHeading>
           <HoverPill primary css={expandPill} onClick={shouldExpand ? expandAll : collapseAll}>
             {shouldExpand ? 'Expand All' : 'Collapse All'}
           </HoverPill>

--- a/ui/src/components/admin/DataDictionary/DictionaryFieldValues.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryFieldValues.js
@@ -37,8 +37,8 @@ const DictionaryFieldValues = () => {
     setNewFieldValue('');
   };
 
-  const editNewField = (originalValue, updatedValue) => {
-    editField(originalValue, updatedValue);
+  const editNewField = (originalValue, updatedValue, isParent) => {
+    editField(originalValue, updatedValue, null, isParent);
   };
 
   const removeNewField = value => {
@@ -91,10 +91,20 @@ const DictionaryFieldValues = () => {
                       : null
                   }
                   editFn={updatedValue =>
-                    editNewField(fieldValue.original || fieldValue.value, updatedValue)
+                    editNewField(
+                      fieldValue.original || fieldValue.value,
+                      updatedValue,
+                      activeField === CLINICAL_TUMOR_DIAGNOSIS,
+                    )
                   }
                   removeFn={() => removeNewField(fieldValue.value)}
-                  resetFn={() => editNewField(fieldValue.original, fieldValue.original)}
+                  resetFn={() =>
+                    editNewField(
+                      fieldValue.original,
+                      fieldValue.original,
+                      activeField === CLINICAL_TUMOR_DIAGNOSIS,
+                    )
+                  }
                 />
               ))}
           </FieldValueList>

--- a/ui/src/components/admin/DataDictionary/DictionaryFieldValues.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryFieldValues.js
@@ -45,6 +45,15 @@ const DictionaryFieldValues = () => {
     removeField(value);
   };
 
+  const hasDirtyDependents = dependents => {
+    if (activeField !== CLINICAL_TUMOR_DIAGNOSIS) return false;
+
+    return (
+      dependents &&
+      dependents.some(dependent => dependent.values.some(value => value.status !== 'published'))
+    );
+  };
+
   return (
     <FieldValues>
       {activeField && (
@@ -79,6 +88,7 @@ const DictionaryFieldValues = () => {
                   initialState={fieldValue.status}
                   original={fieldValue.original}
                   active={activeValue === fieldValue.value}
+                  dirtyDependents={hasDirtyDependents(fieldValue.dependents)}
                   clickHandler={
                     activeField === CLINICAL_TUMOR_DIAGNOSIS
                       ? () => {

--- a/ui/src/components/admin/DataDictionary/DictionaryHeader.js
+++ b/ui/src/components/admin/DataDictionary/DictionaryHeader.js
@@ -39,7 +39,7 @@ const DictionaryHeader = () => {
             Last published: {lastPublished}
             {isDraft && (
               <>
-                <br />
+                <span>|</span>
                 Last updated: {lastUpdated}
               </>
             )}
@@ -76,7 +76,7 @@ const DictionaryHeader = () => {
           {useConfirmationModal({
             title: 'Are you sure you want to publish dictionary updates?',
             message:
-              'These updates will be applied to all applicable models in any state, including published models.',
+              'These updates will be applied to all applicable models in any state. Any published models that have been affected will switch to "Changes not yet published". You can republish them in the model management section.',
             confirmLabel: 'Yes, Publish All Updates',
             onConfirm: publish,
           })(

--- a/ui/src/components/admin/DataDictionary/EditableFieldValue.js
+++ b/ui/src/components/admin/DataDictionary/EditableFieldValue.js
@@ -14,10 +14,12 @@ import {
   FieldValueListItemButton,
   FieldValueListItemContents,
 } from 'theme/adminDictionaryStyles';
+import { StatusIndicator } from 'theme/verticalTabStyles';
 
 const EditableFieldValue = ({
   active,
   clickHandler,
+  dirtyDependents,
   editFn,
   initialValue,
   initialState,
@@ -114,7 +116,12 @@ const EditableFieldValue = ({
           </EditFieldForm>
         );
       default:
-        return <FieldValueListItemLabel>{value}</FieldValueListItemLabel>;
+        return (
+          <FieldValueListItemLabel>
+            {dirtyDependents && <StatusIndicator margin={8} />}
+            {value}
+          </FieldValueListItemLabel>
+        );
     }
   };
 

--- a/ui/src/theme/adminDictionaryStyles.js
+++ b/ui/src/theme/adminDictionaryStyles.js
@@ -2,7 +2,7 @@ import { css } from 'emotion';
 import styled from 'react-emotion';
 import base from 'theme';
 
-import { AdminContent, AdminHeader, AdminHeaderH1 } from 'theme/adminStyles';
+import { AdminContainer, AdminContent, AdminHeader, AdminHeaderH1 } from 'theme/adminStyles';
 import { Col } from 'theme/system';
 import { Row } from 'theme/system';
 
@@ -26,6 +26,10 @@ const {
 } = base;
 
 const borderColour = porcelain;
+
+export const DictionaryContainer = styled(AdminContainer)`
+  margin-bottom: 40px;
+`;
 
 export const DataDictionaryHeader = styled(AdminHeader)`
   position: relative;
@@ -66,6 +70,10 @@ export const DictionaryDraftTimestamp = styled('span')`
   font-stretch: normal;
   font-style: normal;
   line-height: 1.5;
+
+  span {
+    margin: auto 10px;
+  }
 `;
 
 export const DictionaryDraftStats = styled('span')`
@@ -331,6 +339,7 @@ export const FieldValueListItemContentsWrapper = styled('div')`
 export const FieldValueListItemLabel = styled('span')`
   display: flex;
   margin-right: auto;
+  align-items: center;
 `;
 
 export const FieldValueListItemButton = styled('button')`

--- a/ui/src/theme/verticalTabStyles.js
+++ b/ui/src/theme/verticalTabStyles.js
@@ -150,7 +150,7 @@ export const StatusIndicator = styled('span')`
   height: ${({ size }) => size || '7'}px;
   border-radius: 50%;
   background-color: ${seaBuckthorn};
-  margin-right: 4px;
+  margin-right: ${({ margin }) => margin || '4'}px;
 `;
 
 export const Divider = styled('div')`


### PR DESCRIPTION
🐛 Fixes the following bugs found in #609 :
- Maintain the "active" parent after editing a value with dependent fields (so you don't have to re-click the value to see its dependents)
- Fully reset the state upon clicking "Reset" (previously you could end up with a "Dependent Values" column corresponding to a value that no longer exists)
- Sort model form dropdown menu options

💄 Makes the following changes based on feedback from Kim and Rosi:
- Add spacing above footer
- Rearrange dictionary header components
- Show an indicator beside editable fields whose dependents have been modified
- Updated "Publish" modal copy
- Display the name of the value whose dependent fields are being shown (e.x. "Dependent Fields for Ampulla of Vater")