### PR TITLE
🐛 Fix search page content resizing on filtering (#703)

### DIFF
--- a/ui/src/components/Search.js
+++ b/ui/src/components/Search.js
@@ -75,6 +75,7 @@ export default ({
           flex={1}
           css={`
             width: calc(100vw - ${state.panelSize}px);
+            overflow-y: scroll !important;
           `}
         >
           <Row

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -18,6 +18,7 @@ body,
 #root {
   display: flex;
   flex-direction: column;
+  overflow-y: scroll;
 }
 
 *:focus {


### PR DESCRIPTION
* Force `overflow-y: scroll` on root and search-results-wrapper so that 100vw styles respect scrollbar width