### PR TITLE
🐛 Fix model section header overlap on smaller screens (#728)

### DIFF
--- a/ui/src/theme/modelStyles.js
+++ b/ui/src/theme/modelStyles.js
@@ -154,6 +154,7 @@ export default css`
     &__card {
       position: relative;
       padding: 18px;
+      padding-top: 0;
       margin: 8px;
       border: 2px solid ${athensLightGray};
       min-height: 92px;
@@ -168,10 +169,9 @@ export default css`
       margin: 0;
       display: inline-block;
       padding: 2px 15px;
-      position: absolute;
-      bottom: calc(100% - 10px);
       text-transform: uppercase;
       max-width: calc(100% - 32px);
+      transform: translateY(-12px);
     }
   }
 


### PR DESCRIPTION
Prevents section headers on the Model Details page from overlapping the content of other sections on smaller screen sizes