### PR TITLE
Model Details Page GVI API Integration (#653)

### DIFF
--- a/cms/src/helpers/genomicVariants.js
+++ b/cms/src/helpers/genomicVariants.js
@@ -48,7 +48,7 @@ export const addGenomicVariantsFromMaf = async (name, mafData) => {
       const aa_change = (row.HGVSp_Short || '').replace(/^p\./, '');
       const type = row.Variant_Type;
       const transcript_id = row.Transcript_ID;
-      const variant_class = row.VARIANT_CLASS;
+      const variant_class = titleCase(row.VARIANT_CLASS);
       const consequence_type = titleCase((row.Consequence || '').replace(/_/g, ' '));
       const chromosome = row.Chromosome;
       const start_position = row.Start_Position;

--- a/ui/src/components/VariantTables.js
+++ b/ui/src/components/VariantTables.js
@@ -311,6 +311,7 @@ const renderTable = (activeTab, modelName) => {
 
 export default ({ modelName }) => {
   const [activeTab, setActiveTab] = useState(VARIANT_TYPES.clinical);
+  const [isEmpty, setIsEmpty] = useState(true);
   const { fetchData } = useVariants();
 
   useEffect(() => {
@@ -319,10 +320,18 @@ export default ({ modelName }) => {
         modelName,
         type: VARIANT_TYPES.clinical,
       });
+      const histopathologicalBiomarkers = await fetchData({
+        modelName,
+        type: VARIANT_TYPES.histopathological,
+      });
 
-      if (clinicalVariants.length > 0) {
+      if (clinicalVariants.length === 0 && histopathologicalBiomarkers.length === 0) {
+        setIsEmpty(true);
+      } else if (clinicalVariants.length > 0) {
+        setIsEmpty(false);
         setActiveTab(VARIANT_TYPES.clinical);
       } else {
+        setIsEmpty(false);
         setActiveTab(VARIANT_TYPES.histopathological);
       }
     };
@@ -336,42 +345,58 @@ export default ({ modelName }) => {
         position: relative;
       `}
     >
-      <TabGroup width={171}>
-        <Tab
-          active={activeTab === VARIANT_TYPES.clinical}
-          onClick={() => setActiveTab(VARIANT_TYPES.clinical)}
+      {isEmpty ? (
+        <div
+          className="model-details model-details--empty"
+          style={{
+            width: '100%',
+          }}
         >
-          <TabHeading css={activeTab === VARIANT_TYPES.clinical ? variantTabActive : variantTab}>
-            Clinical Sequencing
-          </TabHeading>
-        </Tab>
-        <Tab
-          active={activeTab === VARIANT_TYPES.histopathological}
-          onClick={() => setActiveTab(VARIANT_TYPES.histopathological)}
-        >
-          <TabHeading
-            css={activeTab === VARIANT_TYPES.histopathological ? variantTabActive : variantTab}
+          <VariantsIcon />
+          <p className="model-details__empty-message">No variants available.</p>
+        </div>
+      ) : (
+        <>
+          <TabGroup width={175}>
+            <Tab
+              active={activeTab === VARIANT_TYPES.genomic}
+              onClick={() => setActiveTab(VARIANT_TYPES.genomic)}
+            >
+              <TabHeading css={activeTab === VARIANT_TYPES.genomic ? variantTabActive : variantTab}>
+                Research Somatic Variants
+              </TabHeading>
+            </Tab>
+            <Tab
+              active={activeTab === VARIANT_TYPES.clinical}
+              onClick={() => setActiveTab(VARIANT_TYPES.clinical)}
+            >
+              <TabHeading
+                css={activeTab === VARIANT_TYPES.clinical ? variantTabActive : variantTab}
+              >
+                Clinical Variants
+              </TabHeading>
+            </Tab>
+            <Tab
+              active={activeTab === VARIANT_TYPES.histopathological}
+              onClick={() => setActiveTab(VARIANT_TYPES.histopathological)}
+            >
+              <TabHeading
+                css={activeTab === VARIANT_TYPES.histopathological ? variantTabActive : variantTab}
+              >
+                Histopathological Biomarkers
+              </TabHeading>
+            </Tab>
+          </TabGroup>
+          <div
+            css={`
+              width: calc(100% - 175px);
+              padding-left: 18px;
+            `}
           >
-            Histopathological Biomarkers
-          </TabHeading>
-        </Tab>
-        <Tab
-          active={activeTab === VARIANT_TYPES.genomic}
-          onClick={() => setActiveTab(VARIANT_TYPES.genomic)}
-        >
-          <TabHeading css={activeTab === VARIANT_TYPES.genomic ? variantTabActive : variantTab}>
-            Genomic Sequencing
-          </TabHeading>
-        </Tab>
-      </TabGroup>
-      <div
-        css={`
-          width: calc(100% - 171px);
-          padding-left: 18px;
-        `}
-      >
-        {renderTable(activeTab, modelName)}
-      </div>
+            {renderTable(activeTab, modelName)}
+          </div>
+        </>
+      )}
     </Row>
   );
 };

--- a/ui/src/components/VariantTables.js
+++ b/ui/src/components/VariantTables.js
@@ -17,13 +17,8 @@ import { Row, Col } from 'theme/system';
 import { Tab, TabHeading, variantTab, variantTabActive } from 'theme/verticalTabStyles';
 import { visuallyHidden } from 'theme';
 
+import { VARIANT_TYPES } from 'utils/constants';
 import tsvDownloader from 'utils/tsvDownloader';
-
-const VARIANT_TYPES = {
-  clinical: 'clinical',
-  histopathological: 'histopathological biomarker',
-  genomic: 'genomic_sequencing',
-};
 
 const VariantTable = React.memo(({ type, modelName, columns }) => {
   const {
@@ -266,40 +261,70 @@ const renderTable = (activeTab, modelName) => {
               type: 'keyword',
               sortable: true,
               canChangeShow: true,
-              field: 'name',
-              id: 'variantName',
-              accessor: 'name',
-              Header: 'Name',
+              field: 'variant_id',
+              id: 'variant_id',
+              accessor: 'variant_id',
+              Header: 'Variant',
             },
             {
               show: true,
               type: 'keyword',
               sortable: true,
               canChangeShow: true,
-              field: 'genes',
-              id: 'genes',
-              accessor: 'genes',
-              Header: 'Genes',
+              field: 'gene',
+              id: 'gene',
+              accessor: 'gene',
+              Header: 'Gene',
             },
             {
               show: true,
               type: 'keyword',
               sortable: true,
               canChangeShow: true,
-              field: 'category',
-              id: 'category',
-              accessor: 'category',
+              field: 'aa_change',
+              id: 'aa_change',
+              accessor: 'aa_change',
+              Header: 'AA Change',
+            },
+            {
+              show: true,
+              type: 'keyword',
+              sortable: true,
+              canChangeShow: true,
+              field: 'transcript_id',
+              id: 'transcript_id',
+              accessor: 'transcript_id',
+              Header: 'Transcript',
+            },
+            {
+              show: true,
+              type: 'keyword',
+              sortable: true,
+              canChangeShow: true,
+              field: 'consequence_type',
+              id: 'consequence_type',
+              accessor: 'consequence_type',
+              Header: 'Consequence',
+            },
+            {
+              show: true,
+              type: 'keyword',
+              sortable: true,
+              canChangeShow: true,
+              field: 'class',
+              id: 'class',
+              accessor: 'class',
+              Header: 'Class',
+            },
+            {
+              show: true,
+              type: 'keyword',
+              sortable: true,
+              canChangeShow: true,
+              field: 'type',
+              id: 'type',
+              accessor: 'type',
               Header: 'Type',
-            },
-            {
-              show: true,
-              type: 'keyword',
-              sortable: true,
-              canChangeShow: true,
-              field: 'frequency',
-              id: 'frequency',
-              accessor: 'frequency.display',
-              Header: 'Frequency',
             },
           ]}
         />

--- a/ui/src/providers/Variants.js
+++ b/ui/src/providers/Variants.js
@@ -7,6 +7,7 @@ import { api } from '@arranger/components';
 
 import SparkMeter from 'components/SparkMeter';
 
+import { VARIANT_TYPES } from 'utils/constants';
 import globals from 'utils/globals';
 
 export const VariantsContext = React.createContext([{}, () => {}]);
@@ -67,7 +68,59 @@ export const useVariants = () => {
     return pageSize;
   };
 
+  // TODO: DELETE THIS!
+  // returns dummy Research Somatic Variant data
+  const generateRSVs = numRSVs => {
+    const GENES = ['BRAF', 'IDH1', 'PIK3CA', 'KRA5', 'TP53'];
+    const AA_CHANGES = ['V600G', 'R132H', 'E545K', 'H1047R', 'G12D', 'G12V', 'R175H'];
+    const CONSEQUENCE_TYPES = ['Missense'];
+    const CLASSES = ['SNV'];
+    const TYPES = ['Substitution'];
+    const NUM_CHROMOSOMES = 23;
+
+    const generated = [];
+
+    for (let i = 0; i < numRSVs; i++) {
+      const BASES = ['A', 'T', 'C', 'G'];
+
+      let gene = GENES[Math.floor(Math.random() * GENES.length)];
+      let aa_change = AA_CHANGES[Math.floor(Math.random() * AA_CHANGES.length)];
+      let consequence_type = CONSEQUENCE_TYPES[Math.floor(Math.random() * CONSEQUENCE_TYPES.length)];
+      let variant_class = CLASSES[Math.floor(Math.random() * CLASSES.length)];
+      let variant_type = TYPES[Math.floor(Math.random() * TYPES.length)];
+      let transcript_id = 'ENST000000288602';
+      let chromosome = `chr${Math.floor(Math.random() * NUM_CHROMOSOMES)}`;
+      let startBase = BASES.splice(Math.floor(Math.random() * BASES.length), 1)[0];
+      let endBase = BASES.splice(Math.floor(Math.random() * BASES.length), 1)[0];
+      let startPos = Math.floor(Math.random() * 999999999);
+
+      generated.push({
+        gene: gene,
+        aa_change: aa_change,
+        transcript_id: transcript_id,
+        consequence_type: consequence_type,
+        class: variant_class,
+        type: variant_type,
+        chromosome: chromosome,
+        start_position: startPos,
+        end_position: startPos,
+        specific_change: `${startBase}>${endBase}`,
+        classification: variant_class,
+        variant_id: `${chromosome}:g.${startPos}${startBase}>${endBase}`,
+        name: `${gene} ${aa_change}`,
+      });
+    }
+
+    return generated;
+  };
+
   const fetchData = async ({ modelName, type }) => {
+    // TODO: DELETE THIS!
+    // returns dummy Research Somatic Variant data
+    if (type === VARIANT_TYPES.genomic) {
+      return generateRSVs(25);
+    }
+
     const variantsData = await api({
       endpoint: `/${globals.VERSION}/graphql`,
       body: {

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -1,3 +1,9 @@
 const imgPath = '/api/data/images';
 
-export { imgPath };
+const VARIANT_TYPES = {
+  clinical: 'clinical',
+  histopathological: 'histopathological biomarker',
+  genomic: 'genomic_sequencing',
+};
+
+export { imgPath, VARIANT_TYPES };


### PR DESCRIPTION
💄 Reorder Variants Tabs on Model Details Page, only show tabs if there is data (#653 & #683)
    * Reorder the tabs in the Variants Table on the Model Details Page
    * Rename "Genomic Sequencing" to "Research Somatic Variants"
    * Hide tabs and display empty state when there is no variant/gene data available

🚧 Update Variant Tables to support somatic variant data (#653)
    * Move VARIANT_TYPES to constants file
    * Update columns for Research Somatic Variants table
    * Add dummy data generator for RSVs
    * Temporarily display dummy RSVs to test pagination of table

  ✨ Front-end model details page genomic variants API integration (#653)
    * Remove dummy genomic variant data generator
    * Connect RSV table to API