### PR TITLE
✨ Front-end for CMS Genomic Variant Import (#663) (#658) (#660)

### DIFF
--- a/cms/src/routes/genomicVariants.js
+++ b/cms/src/routes/genomicVariants.js
@@ -46,7 +46,7 @@ variantsRouter.get('/clear/:name', async (req, res) => {
     }
     res.status(200).json({ success: true, model: name });
   } catch (error) {
-    logger.error(...error, `Unexpected error clearing genomic-variants for model ${name}`);
+    logger.error(error, `Unexpected error clearing genomic-variants for model ${name}`);
     res.status(500).json({
       error: error,
     });

--- a/cms/src/routes/genomicVariants.js
+++ b/cms/src/routes/genomicVariants.js
@@ -44,9 +44,9 @@ variantsRouter.get('/clear/:name', async (req, res) => {
     if (!result) {
       res.status(400).json({ success: false, message: 'Model does not exist.' });
     }
-    res.status(200).json({ success: true, model });
+    res.status(200).json({ success: true, model: name });
   } catch (error) {
-    logger.error({ ...error, model: name }, 'Unexpected error clearing genomic-variants for model');
+    logger.error(...error, `Unexpected error clearing genomic-variants for model ${name}`);
     res.status(500).json({
       error: error,
     });
@@ -56,7 +56,7 @@ variantsRouter.get('/clear/:name', async (req, res) => {
 variantsRouter.post('/import/:name', async (req, res) => {
   const { name } = req.params;
   try {
-    logger.debug({ model: name }, `Beginning genomic-variant import for model`);
+    logger.debug(`Beginning genomic-variant import for model ${name}`);
 
     // Clear first before importing new
     await clearGenomicVariants(name);
@@ -68,8 +68,8 @@ variantsRouter.post('/import/:name', async (req, res) => {
     }
 
     res.status(200).json({ success: true, startTime: importStatus.startTime });
-  } catch (e) {
-    console.log(error);
+  } catch (error) {
+    logger.error(error, `Error occurred during genomic-variant import for model ${name}`);
     res.status(500).json({
       error: error,
     });
@@ -78,13 +78,13 @@ variantsRouter.post('/import/:name', async (req, res) => {
 
 variantsRouter.get('/status', async (req, res) => {
   try {
-    console.log(`Fetching active GDC Import Statuses...`);
+    logger.debug(`Fetching active GDC Import Statuses...`);
 
     const imports = VariantImporter.getImports(); // TODO: get from VariantImporter
 
     res.status(200).json({ imports });
-  } catch (e) {
-    console.log(error);
+  } catch (error) {
+    logger.error(error, `Error occurred during GDC Import Status fetch`);
     res.status(500).json({
       error: error,
     });
@@ -94,13 +94,13 @@ variantsRouter.get('/status', async (req, res) => {
 variantsRouter.post('/acknowledge/:name', async (req, res) => {
   const { name } = req.params;
   try {
-    console.log(`Acknowledging import status for: ${name}`);
+    logger.debug(`Acknowledging import status for model ${name}`);
 
     const imports = VariantImporter.acknowledgeCompleted(name); // TODO: get from VariantImporter
 
     res.status(200).json({ imports });
-  } catch (e) {
-    console.log(error);
+  } catch (error) {
+    logger.error(error, `Error occurred during import status acknowledgement for model ${name}`);
     res.status(500).json({
       error: error,
     });

--- a/cms/src/services/gdc-importer/VariantImporter.js
+++ b/cms/src/services/gdc-importer/VariantImporter.js
@@ -176,8 +176,8 @@ const VariantImporter = (function() {
   const acknowledgeCompleted = modelName => {
     const targets = imports.filter(
       i =>
-        i.modelName ===
-        modelName[(ImportStatus.complete, ImportStatus.error)].includes(i.getData().status),
+        i.modelName === modelName &&
+        [ImportStatus.complete, ImportStatus.error].includes(i.getData().status),
     );
     if (targets.length) {
       targets.forEach(target => target.acknowledge());

--- a/ui/src/components/TableDistributorCell.js
+++ b/ui/src/components/TableDistributorCell.js
@@ -13,6 +13,7 @@ export default ({ sqon, savedSetsContext, state, value, history }) => {
       `}
       href={distributorLink(value)}
       target="_blank"
+      rel="noopener noreferrer"
     >
       <ExternalLinkIcon /> {value}
     </a>

--- a/ui/src/components/admin/AdminView.js
+++ b/ui/src/components/admin/AdminView.js
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from 'react';
+import { Route } from 'react-router-dom';
+
+import {
+  acknowledgeImportStatus,
+  checkImportStatus,
+} from 'components/admin/Model/actions/ImportGenomicVariants';
+import { useVariants } from 'providers/Variants';
+
+import AdminNav from './AdminNav';
+import DataDictionary from './DataDictionary';
+import ModelsManager from './ModelsManager';
+import UsersManager from './UsersManager';
+import { ModelSingle } from './Model';
+
+import { AdminMain, AdminWrapper } from 'theme/adminStyles';
+
+import { VARIANT_IMPORT_STATUS } from 'utils/constants';
+import useInterval from 'utils/useInterval';
+
+export default ({ location }) => {
+  const didMountRef = useRef(false);
+  const { importNotifications, addImportNotification, removeImportNotification } = useVariants();
+
+  // Check for active genomic variant imports on page load
+  useEffect(() => {
+    const getActiveImports = async () => {
+      const activeImports = await checkImportStatus();
+
+      if (activeImports && activeImports.length > 0) {
+        activeImports.forEach(activeImport => {
+          addImportNotification(activeImport.name);
+        });
+      }
+    };
+
+    if (!didMountRef || !didMountRef.current) {
+      getActiveImports();
+      didMountRef.current = true;
+    }
+  }, []);
+
+  // Poll for status changes on any active imports
+  useInterval(
+    () => {
+      checkImportStatus().then(activeImports => {
+        if (activeImports.length > 0) {
+          activeImports.forEach(activeImport => {
+            if (activeImport.status === VARIANT_IMPORT_STATUS.complete) {
+              acknowledgeImportStatus(activeImport.name).then(_ => {
+                removeImportNotification(activeImport.name);
+              });
+            }
+          });
+        }
+      });
+    },
+    importNotifications && importNotifications.length > 0 ? 1000 : null,
+  );
+
+  return (
+    <AdminWrapper>
+      <AdminNav location={location} />
+      <AdminMain>
+        <Route exact path="/admin" component={ModelsManager} />
+        <Route exact path="/admin/model/:name?" component={ModelSingle} />
+        <Route exact path="/admin/manage-users" component={UsersManager} />
+        <Route exact path="/admin/data-dictionary" component={DataDictionary} />
+      </AdminMain>
+    </AdminWrapper>
+  );
+};

--- a/ui/src/components/admin/Model/ModelVariants.js
+++ b/ui/src/components/admin/Model/ModelVariants.js
@@ -90,7 +90,7 @@ const TabView = ({ activeTab, clinicalVariantsData, genomicVariantsData, type })
 export default ({ data: { name, genomic_variants, variants, updatedAt } }) => {
   const { appendNotification } = useContext(NotificationsContext);
   const [activeTab, setActiveTab] = useState(null);
-  const { importNotifications, addImportNotification, removeImportNotification } = useVariants();
+  const { importNotifications, addImportNotification } = useVariants();
   const clinicalVariantsData = variants.map(variant => ({
     _id: variant._id,
     variant_name: variant.variant.name,
@@ -199,19 +199,6 @@ export default ({ data: { name, genomic_variants, variants, updatedAt } }) => {
                       >
                         <PlusIcon css={'margin-right: 5px;'} />
                         Research Somatic Variants
-                      </ButtonPill>
-                      <ButtonPill
-                        secondary
-                        css={'margin-left: 10px;'}
-                        disabled={importNotifications.length === 0}
-                        onClick={() => {
-                          if (importNotifications.length > 0) {
-                            removeImportNotification(name);
-                          }
-                        }}
-                      >
-                        <PlusIcon css={'margin-right: 5px;'} />
-                        Clear Import Notification
                       </ButtonPill>
                     </>
                   )}

--- a/ui/src/components/admin/Model/actions/ImportGenomicVariants.js
+++ b/ui/src/components/admin/Model/actions/ImportGenomicVariants.js
@@ -5,7 +5,7 @@ import config from './../../config';
 
 import { MessageLink } from 'theme/adminNotificationStyles';
 
-const GENOMIC_VARIANTS_URL = `${config.urls.cmsBase}/genomic_variants`;
+const GENOMIC_VARIANTS_URL = `${config.urls.cmsBase}/genomic-variants`;
 const FILE_PAGE_URL_BASE = 'https://portal.gdc.cancer.gov/files';
 const CASE_URL_BASE = 'https://portal.gdc.cancer.gov/cases';
 

--- a/ui/src/components/admin/Model/actions/ImportGenomicVariants.js
+++ b/ui/src/components/admin/Model/actions/ImportGenomicVariants.js
@@ -83,7 +83,7 @@ export const checkImportStatus = async () => {
     const url = `${GENOMIC_VARIANTS_URL}/status`;
     await get({ url })
       .then(res => {
-        resolve(res);
+        resolve(res.data.imports);
       })
       .catch(err => {
         reject(err);

--- a/ui/src/components/admin/Model/actions/ImportGenomicVariants.js
+++ b/ui/src/components/admin/Model/actions/ImportGenomicVariants.js
@@ -1,0 +1,105 @@
+import React from 'react';
+
+import { get, post } from './../../services/Fetcher';
+import config from './../../config';
+
+import { MessageLink } from 'theme/adminNotificationStyles';
+
+const GENOMIC_VARIANTS_URL = `${config.urls.cmsBase}/genomic_variants`;
+const FILE_PAGE_URL_BASE = 'https://portal.gdc.cancer.gov/files';
+const CASE_URL_BASE = 'https://portal.gdc.cancer.gov/cases';
+
+export const GENOMIC_VARIANTS_IMPORT_ERRORS = {
+  multipleMaf: 'MULTIPLE_MAFS',
+  noMaf: 'NO_MAFS',
+  modelNotFound: 'MODEL_NOT_FOUND',
+};
+
+export const MultipleMafError = ({ files }) => {
+  return (files || [])
+    .map((file, index, array) => {
+      const fileUrl = `${FILE_PAGE_URL_BASE}/${file.file_id}`;
+      return index === array.length - 1 ? (
+        <>
+          {`and `}
+          <MessageLink to={fileUrl} target="_blank" rel="noopener noreferrer">
+            {file.file_name}
+          </MessageLink>
+          {`. `}
+        </>
+      ) : (
+        <>
+          <MessageLink to={fileUrl} target="_blank" rel="noopener noreferrer">
+            {file.file_name}
+          </MessageLink>
+          {`, `}
+        </>
+      );
+    })
+    .concat('Please investigate with the GDC team and try again later.');
+};
+
+export const NoMafError = ({ caseId, modelName }) => {
+  const caseUrl = `${CASE_URL_BASE}/${caseId}`;
+
+  return (
+    <>
+      <MessageLink to={caseUrl} target="_blank" rel="noopener noreferrer">
+        {modelName}
+      </MessageLink>
+      {` was found on GDC but no open Next Generation Cancer Model MAF files were found.`}
+    </>
+  );
+};
+
+export const importGenomicVariants = async modelName => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${GENOMIC_VARIANTS_URL}/import/${modelName}`;
+    await post({ url })
+      .then(res => {
+        resolve(res);
+      })
+      .catch(err => {
+        reject(err);
+      });
+  });
+};
+
+export const clearGenomicVariants = async modelName => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${GENOMIC_VARIANTS_URL}/clear/${modelName}`;
+    await get({ url })
+      .then(res => {
+        resolve(res);
+      })
+      .catch(err => {
+        reject(err);
+      });
+  });
+};
+
+export const checkImportStatus = async () => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${GENOMIC_VARIANTS_URL}/status`;
+    await get({ url })
+      .then(res => {
+        resolve(res);
+      })
+      .catch(err => {
+        reject(err);
+      });
+  });
+};
+
+export const acknowledgeImportStatus = async modelName => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${GENOMIC_VARIANTS_URL}/acknowledge/${modelName}`;
+    await post({ url })
+      .then(res => {
+        resolve(res);
+      })
+      .catch(err => {
+        reject(err);
+      });
+  });
+};

--- a/ui/src/components/admin/Notifications/NotificationsController.js
+++ b/ui/src/components/admin/Notifications/NotificationsController.js
@@ -4,7 +4,6 @@ export const NotificationsContext = React.createContext();
 
 const NotificationsProvider = ({ children }) => {
   const [notifications, setNotifications] = useState([]);
-  const [importNotification, setImportNotification] = useState(null);
 
   const appendNotification = notification => {
     const id = Date.now();
@@ -51,8 +50,6 @@ const NotificationsProvider = ({ children }) => {
         setNotifications,
         appendNotification,
         clearNotification,
-        importNotification,
-        setImportNotification,
       }}
     >
       {children}

--- a/ui/src/components/admin/Notifications/NotificationsController.js
+++ b/ui/src/components/admin/Notifications/NotificationsController.js
@@ -4,6 +4,7 @@ export const NotificationsContext = React.createContext();
 
 const NotificationsProvider = ({ children }) => {
   const [notifications, setNotifications] = useState([]);
+  const [importNotification, setImportNotification] = useState(null);
 
   const appendNotification = notification => {
     const id = Date.now();
@@ -45,7 +46,14 @@ const NotificationsProvider = ({ children }) => {
 
   return (
     <NotificationsContext.Provider
-      value={{ notifications, setNotifications, appendNotification, clearNotification }}
+      value={{
+        notifications,
+        setNotifications,
+        appendNotification,
+        clearNotification,
+        importNotification,
+        setImportNotification,
+      }}
     >
       {children}
     </NotificationsContext.Provider>

--- a/ui/src/components/admin/index.js
+++ b/ui/src/components/admin/index.js
@@ -1,29 +1,17 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+
+import AdminView from './AdminView';
 
 import { NotificationsProvider } from './Notifications';
-
-import AdminNav from './AdminNav';
-import DataDictionary from './DataDictionary';
-import ModelsManager from './ModelsManager';
-import UsersManager from './UsersManager';
-import { ModelSingle } from './Model';
-
-import { AdminMain, AdminWrapper } from 'theme/adminStyles';
 import { LoggedInUserProvider } from '@hcmi-portal/ui/src/components/admin/services/LoggedInUser';
+import { VariantsProvider } from 'providers/Variants';
 
 export default ({ location }) => (
   <NotificationsProvider>
     <LoggedInUserProvider>
-      <AdminWrapper>
-        <AdminNav location={location} />
-        <AdminMain>
-          <Route exact path="/admin" component={ModelsManager} />
-          <Route exact path="/admin/model/:name?" component={ModelSingle} />
-          <Route exact path="/admin/manage-users" component={UsersManager} />
-          <Route exact path="/admin/data-dictionary" component={DataDictionary} />
-        </AdminMain>
-      </AdminWrapper>
+      <VariantsProvider>
+        <AdminView location={location} />
+      </VariantsProvider>
     </LoggedInUserProvider>
   </NotificationsProvider>
 );

--- a/ui/src/providers/Variants.js
+++ b/ui/src/providers/Variants.js
@@ -322,10 +322,6 @@ export const useVariants = () => {
           notificationId: notification.id,
         },
       ]);
-      console.log('adding import notification for ', modelName);
-    } else {
-      console.log('already existed for ', modelName);
-      console.log('existingNotification is ', existingNotification);
     }
   };
 

--- a/ui/src/providers/Variants.js
+++ b/ui/src/providers/Variants.js
@@ -7,6 +7,8 @@ import { api } from '@arranger/components';
 
 import SparkMeter from 'components/SparkMeter';
 
+import { NotificationsContext, NOTIFICATION_TYPES } from 'components/admin/Notifications';
+
 import { VARIANT_TYPES } from 'utils/constants';
 import globals from 'utils/globals';
 
@@ -18,6 +20,7 @@ export const VariantsProvider = props => {
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
+  const [importNotifications, setImportNotifications] = useState([]);
 
   return (
     <VariantsContext.Provider
@@ -27,6 +30,7 @@ export const VariantsProvider = props => {
         [loading, setLoading],
         [page, setPage],
         [pageSize, setPageSize],
+        [importNotifications, setImportNotifications],
       ]}
     >
       {props.children}
@@ -41,7 +45,9 @@ export const useVariants = () => {
     [loading, setLoading],
     [page, setPage],
     [pageSize, setPageSize],
+    [importNotifications, setImportNotifications],
   ] = useContext(VariantsContext);
+  const { appendNotification, clearNotification } = useContext(NotificationsContext);
 
   const getData = () => {
     if (!data) return [];
@@ -51,6 +57,11 @@ export const useVariants = () => {
   const getFilteredData = () => {
     if (!filteredData) return [];
     return filteredData;
+  };
+
+  const getImportNotifications = () => {
+    if (!importNotifications) return [];
+    return importNotifications;
   };
 
   const getLoading = () => {
@@ -292,17 +303,64 @@ export const useVariants = () => {
     return b.frequency.raw - a.frequency.raw;
   };
 
+  const addImportNotification = async modelName => {
+    const existingNotification = getImportNotifications().find(x => x.modelName === modelName);
+
+    if (!existingNotification) {
+      const notification = await appendNotification({
+        type: NOTIFICATION_TYPES.LOADING,
+        message: `Importing: Research Variants for ${modelName} are currently importing.`,
+        details:
+          'You can continue to use the CMS, and will be notified when the import is complete.',
+        timeout: false,
+      });
+
+      setImportNotifications(notifications => [
+        ...notifications,
+        {
+          modelName: modelName,
+          notificationId: notification.id,
+        },
+      ]);
+      console.log('adding import notification for ', modelName);
+    } else {
+      console.log('already existed for ', modelName);
+      console.log('existingNotification is ', existingNotification);
+    }
+  };
+
+  const removeImportNotification = modelName => {
+    const existingNotification = getImportNotifications().find(x => x.modelName === modelName);
+
+    if (existingNotification) {
+      clearNotification(existingNotification.notificationId);
+      setImportNotifications(notifications =>
+        notifications.filter(notification => notification.modelName !== modelName),
+      );
+      appendNotification({
+        type: NOTIFICATION_TYPES.SUCCESS,
+        message: `Import Successful: Research Somatic Variants for ${modelName} have successfully imported, however are not yet published.`,
+        link: `/admin/model/${modelName}`,
+        linkText: 'View on model page to publish these variants.',
+      });
+    }
+  };
+
   return {
     data: getData(),
     filteredData: getFilteredData(),
+    importNotifications: getImportNotifications(),
     loading: getLoading(),
     page: getPage(),
     pageSize: getPageSize(),
     setData,
     setFilteredData,
+    setImportNotifications,
     setLoading,
     setPage,
     setPageSize,
+    addImportNotification,
+    removeImportNotification,
     fetchData,
     sortFilteredData,
   };

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -6,4 +6,11 @@ const VARIANT_TYPES = {
   genomic: 'genomic_sequencing',
 };
 
-export { imgPath, VARIANT_TYPES };
+const VARIANT_IMPORT_STATUS = {
+  active: 'ACTIVE',
+  complete: 'COMPLETE',
+  error: 'ERROR',
+  stopped: 'STOPPED',
+};
+
+export { imgPath, VARIANT_TYPES, VARIANT_IMPORT_STATUS };

--- a/ui/src/utils/useInterval.js
+++ b/ui/src/utils/useInterval.js
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+
+// Custom hook by Dan Abramov
+// https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+const useInterval = (callback, delay) => {
+  const savedCallback = useRef();
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    const tick = () => {
+      savedCallback.current();
+    };
+
+    if (delay !== null) {
+      let id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+};
+
+export default useInterval;


### PR DESCRIPTION
~Pretty close, but still a few things to work on. Namely, there seems to be a bug with the acknowledge endpoint that's causing the polling functionality to get stuck right now. Need to add some more error handling as well. There's also a temporary "Clear Import Notification" button on the CMS model page that will be removed once the acknowledge bug is gone.~

**Update: the acknowledge bug has been fixed and the "Clear Import Notification" has been removed. The "happy path" for a successful genomic variant import is working now 🎉** 

Commits:
- 🔒 Add rel="noopener noreferrer" to external link to Distributor
- 🔊 Update logging for genomic variant import in CMS
- ✨ Connect CMS Import Research Somatic Variants to API (#663)
    * Add front-end functions to make API calls to GVI import API
    * Add notifications for success/error states for GVI import
    * Temporarily add a button to close the "Importing" notification that appears on GVI import start
- 🐛 Fix genomic variants URL in front-end API requests
- ✨ Add `useInterval` hook for polling purposes
- ✨ Connect import genomic variants API, add async notifications (#663) (#658)
    * Refactor Admin to move provider wrappings to a parent component
    * Refactor genomic variant importing and notifications on the front-end
    * Add polling for ongoing imports
    * Check for ongoing imports on return to admin
    * Clear import notifications once import status is changed to complete