### PR TITLE
🐛 Refactor to remove shared code between admin and non-admin for Genomic Variants

### DIFF
--- a/ui/src/components/admin/AdminView.js
+++ b/ui/src/components/admin/AdminView.js
@@ -5,7 +5,7 @@ import {
   acknowledgeImportStatus,
   checkImportStatus,
 } from 'components/admin/Model/actions/ImportGenomicVariants';
-import { useVariants } from 'providers/Variants';
+import { useGenomicVariantImportNotifications } from 'components/admin/Notifications';
 
 import AdminNav from './AdminNav';
 import DataDictionary from './DataDictionary';
@@ -20,7 +20,12 @@ import useInterval from 'utils/useInterval';
 
 export default ({ location }) => {
   const didMountRef = useRef(false);
-  const { importNotifications, addImportNotification, removeImportNotification } = useVariants();
+  const {
+    importNotifications,
+    addImportNotification,
+    removeImportNotification,
+    showSuccessfulImportNotification,
+  } = useGenomicVariantImportNotifications();
 
   // Check for active genomic variant imports on page load
   useEffect(() => {
@@ -49,6 +54,7 @@ export default ({ location }) => {
             if (activeImport.status === VARIANT_IMPORT_STATUS.complete) {
               acknowledgeImportStatus(activeImport.name).then(_ => {
                 removeImportNotification(activeImport.name);
+                showSuccessfulImportNotification(activeImport.name);
               });
             }
           });

--- a/ui/src/components/admin/Model/ModelVariants.js
+++ b/ui/src/components/admin/Model/ModelVariants.js
@@ -8,8 +8,11 @@ import {
   MultipleMafError,
   NoMafError,
 } from './actions/ImportGenomicVariants';
-import { NotificationsContext, NOTIFICATION_TYPES } from './../Notifications';
-import { useVariants } from 'providers/Variants';
+import {
+  NotificationsContext,
+  NOTIFICATION_TYPES,
+  useGenomicVariantImportNotifications,
+} from './../Notifications';
 
 import { Toolbar, DataTable, GenomicDataTable } from '../AdminTable';
 import BulkUploader from '../BulkUpload';
@@ -90,7 +93,7 @@ const TabView = ({ activeTab, clinicalVariantsData, genomicVariantsData, type })
 export default ({ data: { name, genomic_variants, variants, updatedAt } }) => {
   const { appendNotification } = useContext(NotificationsContext);
   const [activeTab, setActiveTab] = useState(null);
-  const { importNotifications, addImportNotification } = useVariants();
+  const { importNotifications, addImportNotification } = useGenomicVariantImportNotifications();
   const clinicalVariantsData = variants.map(variant => ({
     _id: variant._id,
     variant_name: variant.variant.name,

--- a/ui/src/components/admin/Notifications/GenomicVariantImportNotifications.js
+++ b/ui/src/components/admin/Notifications/GenomicVariantImportNotifications.js
@@ -1,0 +1,70 @@
+import { useContext } from 'react';
+
+import { NotificationsContext } from './NotificationsController';
+import NOTIFICATION_TYPES from './NotificationTypes';
+
+const useGenomicVariantImportNotifications = () => {
+  const {
+    appendNotification,
+    clearNotification,
+    importNotifications,
+    setImportNotifications,
+  } = useContext(NotificationsContext);
+
+  const getImportNotifications = () => {
+    if (!importNotifications) return [];
+    return importNotifications;
+  };
+
+  const addImportNotification = async modelName => {
+    const existingNotification = getImportNotifications().find(x => x.modelName === modelName);
+
+    if (!existingNotification) {
+      const notification = await appendNotification({
+        type: NOTIFICATION_TYPES.LOADING,
+        message: `Importing: Research Variants for ${modelName} are currently importing.`,
+        details:
+          'You can continue to use the CMS, and will be notified when the import is complete.',
+        timeout: false,
+      });
+
+      setImportNotifications(notifications => [
+        ...notifications,
+        {
+          modelName: modelName,
+          notificationId: notification.id,
+        },
+      ]);
+    }
+  };
+
+  const removeImportNotification = modelName => {
+    const existingNotification = getImportNotifications().find(x => x.modelName === modelName);
+
+    if (existingNotification) {
+      clearNotification(existingNotification.notificationId);
+      setImportNotifications(notifications =>
+        notifications.filter(notification => notification.modelName !== modelName),
+      );
+    }
+  };
+
+  const showSuccessfulImportNotification = modelName => {
+    appendNotification({
+      type: NOTIFICATION_TYPES.SUCCESS,
+      message: `Import Successful: Research Somatic Variants for ${modelName} have successfully imported, however are not yet published.`,
+      link: `/admin/model/${modelName}`,
+      linkText: 'View on model page to publish these variants.',
+    });
+  };
+
+  return {
+    importNotifications: getImportNotifications(),
+    setImportNotifications,
+    addImportNotification,
+    removeImportNotification,
+    showSuccessfulImportNotification,
+  };
+};
+
+export default useGenomicVariantImportNotifications;

--- a/ui/src/components/admin/Notifications/NotificationsController.js
+++ b/ui/src/components/admin/Notifications/NotificationsController.js
@@ -1,6 +1,4 @@
-import React, { useContext, useState } from 'react';
-
-import NOTIFICATION_TYPES from './NotificationTypes';
+import React, { useState } from 'react';
 
 export const NotificationsContext = React.createContext();
 
@@ -60,70 +58,6 @@ const NotificationsProvider = ({ children }) => {
       {children}
     </NotificationsContext.Provider>
   );
-};
-
-export const useGenomicVariantImportNotifications = () => {
-  const {
-    appendNotification,
-    clearNotification,
-    importNotifications,
-    setImportNotifications,
-  } = useContext(NotificationsContext);
-
-  const getImportNotifications = () => {
-    if (!importNotifications) return [];
-    return importNotifications;
-  };
-
-  const addImportNotification = async modelName => {
-    const existingNotification = getImportNotifications().find(x => x.modelName === modelName);
-
-    if (!existingNotification) {
-      const notification = await appendNotification({
-        type: NOTIFICATION_TYPES.LOADING,
-        message: `Importing: Research Variants for ${modelName} are currently importing.`,
-        details:
-          'You can continue to use the CMS, and will be notified when the import is complete.',
-        timeout: false,
-      });
-
-      setImportNotifications(notifications => [
-        ...notifications,
-        {
-          modelName: modelName,
-          notificationId: notification.id,
-        },
-      ]);
-    }
-  };
-
-  const removeImportNotification = modelName => {
-    const existingNotification = getImportNotifications().find(x => x.modelName === modelName);
-
-    if (existingNotification) {
-      clearNotification(existingNotification.notificationId);
-      setImportNotifications(notifications =>
-        notifications.filter(notification => notification.modelName !== modelName),
-      );
-    }
-  };
-
-  const showSuccessfulImportNotification = modelName => {
-    appendNotification({
-      type: NOTIFICATION_TYPES.SUCCESS,
-      message: `Import Successful: Research Somatic Variants for ${modelName} have successfully imported, however are not yet published.`,
-      link: `/admin/model/${modelName}`,
-      linkText: 'View on model page to publish these variants.',
-    });
-  };
-
-  return {
-    importNotifications: getImportNotifications(),
-    setImportNotifications,
-    addImportNotification,
-    removeImportNotification,
-    showSuccessfulImportNotification,
-  };
 };
 
 export default NotificationsProvider;

--- a/ui/src/components/admin/Notifications/index.js
+++ b/ui/src/components/admin/Notifications/index.js
@@ -1,3 +1,7 @@
 export { default as NotificationToaster } from './NotificationToaster';
-export { default as NotificationsProvider, NotificationsContext } from './NotificationsController';
+export {
+  default as NotificationsProvider,
+  NotificationsContext,
+  useGenomicVariantImportNotifications,
+} from './NotificationsController';
 export { default as NOTIFICATION_TYPES } from './NotificationTypes';

--- a/ui/src/components/admin/Notifications/index.js
+++ b/ui/src/components/admin/Notifications/index.js
@@ -1,7 +1,6 @@
 export { default as NotificationToaster } from './NotificationToaster';
-export {
-  default as NotificationsProvider,
-  NotificationsContext,
-  useGenomicVariantImportNotifications,
-} from './NotificationsController';
+export { default as NotificationsProvider, NotificationsContext } from './NotificationsController';
 export { default as NOTIFICATION_TYPES } from './NotificationTypes';
+export {
+  default as useGenomicVariantImportNotifications,
+} from './GenomicVariantImportNotifications';

--- a/ui/src/providers/Variants.js
+++ b/ui/src/providers/Variants.js
@@ -7,8 +7,6 @@ import { api } from '@arranger/components';
 
 import SparkMeter from 'components/SparkMeter';
 
-import { NotificationsContext, NOTIFICATION_TYPES } from 'components/admin/Notifications';
-
 import { VARIANT_TYPES } from 'utils/constants';
 import globals from 'utils/globals';
 
@@ -20,7 +18,6 @@ export const VariantsProvider = props => {
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
-  const [importNotifications, setImportNotifications] = useState([]);
 
   return (
     <VariantsContext.Provider
@@ -30,7 +27,6 @@ export const VariantsProvider = props => {
         [loading, setLoading],
         [page, setPage],
         [pageSize, setPageSize],
-        [importNotifications, setImportNotifications],
       ]}
     >
       {props.children}
@@ -45,9 +41,7 @@ export const useVariants = () => {
     [loading, setLoading],
     [page, setPage],
     [pageSize, setPageSize],
-    [importNotifications, setImportNotifications],
   ] = useContext(VariantsContext);
-  const { appendNotification, clearNotification } = useContext(NotificationsContext);
 
   const getData = () => {
     if (!data) return [];
@@ -57,11 +51,6 @@ export const useVariants = () => {
   const getFilteredData = () => {
     if (!filteredData) return [];
     return filteredData;
-  };
-
-  const getImportNotifications = () => {
-    if (!importNotifications) return [];
-    return importNotifications;
   };
 
   const getLoading = () => {
@@ -303,60 +292,17 @@ export const useVariants = () => {
     return b.frequency.raw - a.frequency.raw;
   };
 
-  const addImportNotification = async modelName => {
-    const existingNotification = getImportNotifications().find(x => x.modelName === modelName);
-
-    if (!existingNotification) {
-      const notification = await appendNotification({
-        type: NOTIFICATION_TYPES.LOADING,
-        message: `Importing: Research Variants for ${modelName} are currently importing.`,
-        details:
-          'You can continue to use the CMS, and will be notified when the import is complete.',
-        timeout: false,
-      });
-
-      setImportNotifications(notifications => [
-        ...notifications,
-        {
-          modelName: modelName,
-          notificationId: notification.id,
-        },
-      ]);
-    }
-  };
-
-  const removeImportNotification = modelName => {
-    const existingNotification = getImportNotifications().find(x => x.modelName === modelName);
-
-    if (existingNotification) {
-      clearNotification(existingNotification.notificationId);
-      setImportNotifications(notifications =>
-        notifications.filter(notification => notification.modelName !== modelName),
-      );
-      appendNotification({
-        type: NOTIFICATION_TYPES.SUCCESS,
-        message: `Import Successful: Research Somatic Variants for ${modelName} have successfully imported, however are not yet published.`,
-        link: `/admin/model/${modelName}`,
-        linkText: 'View on model page to publish these variants.',
-      });
-    }
-  };
-
   return {
     data: getData(),
     filteredData: getFilteredData(),
-    importNotifications: getImportNotifications(),
     loading: getLoading(),
     page: getPage(),
     pageSize: getPageSize(),
     setData,
     setFilteredData,
-    setImportNotifications,
     setLoading,
     setPage,
     setPageSize,
-    addImportNotification,
-    removeImportNotification,
     fetchData,
     sortFilteredData,
   };


### PR DESCRIPTION
* Refactor all genomic variant import notification code to the admin-only NotificationsContext
* Split removeImportNotification into separate functions for removing the import notification and showing the successful import notification