### PR TITLE
Variant Chart Update & Data Refresh on Import Completion

### DIFF
--- a/ui/src/components/admin/Model/ModelSingleController.js
+++ b/ui/src/components/admin/Model/ModelSingleController.js
@@ -722,6 +722,45 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
                 state.data.response.genomic_variants || [],
                 'genomicVariantTable',
               ),
+              fetchGenomicVariantData: async modelName => {
+                if (modelName) {
+                  // Set loading true
+                  setState(state => ({
+                    data: {
+                      ...state.data,
+                      isLoading: true,
+                    },
+                  }));
+
+                  try {
+                    const modelDataResponse = await getModel(baseUrl, modelName);
+
+                    setState(state => ({
+                      data: {
+                        ...state.data,
+                        isLoading: false,
+                        didLoad: true,
+                        response: {
+                          ...state.data.response,
+                          genomic_variants: modelDataResponse.data.genomic_variants,
+                        },
+                      },
+                      genomicVariantTable: {
+                        ...state.genomicVariantTable,
+                        rowCount: (modelDataResponse.data.genomic_variants || []).length,
+                      },
+                    }));
+                  } catch (err) {
+                    setState(state => ({
+                      data: {
+                        ...state.data,
+                        isLoading: false,
+                        error: err,
+                      },
+                    }));
+                  }
+                }
+              },
             }}
             {...props}
           >

--- a/ui/src/components/charts/TopVariantsChart.js
+++ b/ui/src/components/charts/TopVariantsChart.js
@@ -82,19 +82,7 @@ export default ({ sqon, setSQON }) => (
                 (largest, { doc_count }) => (doc_count > largest ? doc_count : largest),
                 0,
               ),
-              // returns a "nice" number for the y-axis upper limit
-              // ex. largest 17 => 20, largest 177 => 200, largest 1777 => 2000
-              maxY = () => {
-                if (largestCount <= 1) {
-                  return largestCount;
-                }
-
-                const log = Math.floor(Math.log10(largestCount));
-                const step = Math.pow(10, log === 0 ? 1 : log);
-
-                return Math.ceil(largestCount / step) * step;
-              },
-              yGridValues = largestCount > 0 ? [0, maxY()] : [],
+              yGridValues = largestCount > 0 ? [0, largestCount] : [],
             }) => {
               return loading ? (
                 <span className="sqon-field sqon-field--chart-title">Loading...</span>
@@ -111,7 +99,7 @@ export default ({ sqon, setSQON }) => (
                       left: 48,
                     }}
                     data={coloredTop10}
-                    maxValue={maxY()}
+                    maxValue={largestCount}
                     enableLabel={false}
                     padding={0.4}
                     indexBy="key"


### PR DESCRIPTION
💄 Change max value on top variants chart back to max number of variants instead of pretty number
✨ Trigger an update of genomic variant data on import completion
    * If on the CMS page for the model whose import has just completed, fetch and display the latest data