### PR TITLE
✨ Add confirmation modal when overwriting existing genomic variants (#734)

### DIFF
--- a/ui/src/components/admin/Model/ModelVariants.js
+++ b/ui/src/components/admin/Model/ModelVariants.js
@@ -227,13 +227,12 @@ export default ({ data: { name, gene_metadata, genomic_variants, variants, updat
                         <PlusIcon css={'margin-right: 5px;'} />
                         Clinical Variants
                       </ButtonPill>
-                      <ButtonPill
-                        primary
-                        css={'margin-left: 10px;'}
-                        disabled={importNotifications.find(
-                          notification => notification.modelName === name,
-                        )}
-                        onClick={() => {
+                      {useConfirmationModal({
+                        title: 'Overwrite Existing Variants?',
+                        message:
+                          'Are you sure you want to import new research variants and overwrite the existing list?',
+                        confirmLabel: 'Yes, Import',
+                        onConfirm: () => {
                           importGenomicVariants(name)
                             .then(async response => {
                               addImportNotification(name);
@@ -273,11 +272,20 @@ export default ({ data: { name, gene_metadata, genomic_variants, variants, updat
                                   break;
                               }
                             });
-                        }}
-                      >
-                        <PlusIcon css={'margin-right: 5px;'} />
-                        Research Somatic Variants
-                      </ButtonPill>
+                        },
+                        confirmationRequired: genomicVariantsData.length > 0,
+                      })(
+                        <ButtonPill
+                          primary
+                          css={'margin-left: 10px;'}
+                          disabled={importNotifications.find(
+                            notification => notification.modelName === name,
+                          )}
+                        >
+                          <PlusIcon css={'margin-right: 5px;'} />
+                          Research Somatic Variants
+                        </ButtonPill>,
+                      )}
                     </>
                   )}
                 </ModalStateContext.Consumer>

--- a/ui/src/components/modals/ConfirmationModal.js
+++ b/ui/src/components/modals/ConfirmationModal.js
@@ -52,6 +52,7 @@ const ConfirmationModal = ({
 export default ({
   title,
   message,
+  confirmationRequired = true,
   confirmLabel,
   cancelLabel,
   onConfirm,
@@ -60,16 +61,21 @@ export default ({
   <ModalStateContext.Consumer>
     {modalState =>
       React.cloneElement(Component, {
-        onClick: () =>
-          modalState.setModalState({
-            component: (
-              <ConfirmationModal
-                {...{ title, message, confirmLabel, cancelLabel, onConfirm, onCancel }}
-              />
-            ),
-            shouldCloseOnOverlayClick: true,
-            styles: AdminModalStyleNarrow,
-          }),
+        onClick: () => {
+          if (confirmationRequired) {
+            modalState.setModalState({
+              component: (
+                <ConfirmationModal
+                  {...{ title, message, confirmLabel, cancelLabel, onConfirm, onCancel }}
+                />
+              ),
+              shouldCloseOnOverlayClick: true,
+              styles: AdminModalStyleNarrow,
+            });
+          } else {
+            onConfirm();
+          }
+        },
       })
     }
   </ModalStateContext.Consumer>


### PR DESCRIPTION
* Add `confirmationRequired` prop to ConfirmationModal to conditionally show the confirmation modal
* Show confirmation modal only if there is an existing list of genomic variants of length > 0