### PR TITLE
✨ Persist Expanded/Unexpanded Toggle State, Update Unexpanded Model Count with Filters

### DIFF
--- a/ui/src/components/App.js
+++ b/ui/src/components/App.js
@@ -18,6 +18,7 @@ import WarningModal from 'components/modals/WarningModal';
 
 import RootProvider from 'providers/RootProvider';
 import { ModalStateContext } from 'providers/ModalState';
+import { ExpandedUnexpandedProvider } from 'providers/ExpandedUnexpanded';
 import base from 'theme';
 
 // issue with react-router and react context provider workaround:
@@ -38,7 +39,7 @@ const ProvidedRoutes = () => (
         }}
       >
         {({ state }) => (
-          <>
+          <ExpandedUnexpandedProvider>
             <Switch>
               <Route
                 path="/"
@@ -83,7 +84,7 @@ const ProvidedRoutes = () => (
               />
             </Switch>
             <Footer />
-          </>
+          </ExpandedUnexpandedProvider>
         )}
       </Component>
     )}

--- a/ui/src/components/Header.js
+++ b/ui/src/components/Header.js
@@ -1,10 +1,18 @@
 import React from 'react';
 
+import { useExpandedUnexpanded } from 'providers/ExpandedUnexpanded';
+
 import { Header, HeaderLink, subheadingStyle } from 'theme/headerStyles';
 
-export default ({ subheading = 'Searchable Catalog' }) => (
-  <Header>
-    <HeaderLink to="/">Human Cancer Models Initiative</HeaderLink>
-    <div css={subheadingStyle}>{subheading}</div>
-  </Header>
-);
+export default ({ subheading = 'Searchable Catalog' }) => {
+  const { resetShowUnexpanded } = useExpandedUnexpanded();
+
+  return (
+    <Header>
+      <HeaderLink onClick={() => resetShowUnexpanded()} to="/">
+        Human Cancer Models Initiative
+      </HeaderLink>
+      <div css={subheadingStyle}>{subheading}</div>
+    </Header>
+  );
+};

--- a/ui/src/components/ModelBar.js
+++ b/ui/src/components/ModelBar.js
@@ -43,7 +43,9 @@ export default ({ name, id, isExpanded }) => {
       Object.keys(sets[sqon.content.value].sqon).length !== 0
       ? {
           pathname: '/',
-          search: stringify({ sqon: JSON.stringify(sets[sqon.content.value].sqon) }),
+          search: stringify({
+            sqon: JSON.stringify(filterExpanded(sets[sqon.content.value].sqon)),
+          }),
         }
       : '/';
   };
@@ -60,7 +62,7 @@ export default ({ name, id, isExpanded }) => {
           </div>
 
           <div className="model-bar__group">
-            <Link className="model-bar__back" to={getBackRoute(filterExpanded(sqon))}>
+            <Link className="model-bar__back" to={getBackRoute(sqon)}>
               <ArrowLeftIcon
                 css={`
                   margin-right: 5px;

--- a/ui/src/components/VariantTables.js
+++ b/ui/src/components/VariantTables.js
@@ -154,7 +154,7 @@ const VariantTable = React.memo(({ type, modelName, columns }) => {
           >
             <VariantsIcon />
             <p className="model-details__empty-message">
-              {type === VARIANT_TYPES.genomic && geneMetadata
+              {type === VARIANT_TYPES.genomic && geneMetadata && geneMetadata.filename
                 ? 'No variants were identified in the Masked Somatic MAF file.'
                 : 'No variants available.'}
             </p>
@@ -392,7 +392,7 @@ export default ({ modelName }) => {
         clinicalVariants.length === 0 &&
         genomicVariants.length === 0 &&
         histopathologicalBiomarkers.length === 0 &&
-        !geneMetadata
+        !geneMetadata.filename
       ) {
         setIsEmpty(true);
       } else if (clinicalVariants.length > 0) {
@@ -400,7 +400,7 @@ export default ({ modelName }) => {
         setActiveTab(VARIANT_TYPES.clinical);
         setData(clinicalVariants);
         setFilteredData(clinicalVariants);
-      } else if (genomicVariants.length > 0 || geneMetadata) {
+      } else if (genomicVariants.length > 0 || (geneMetadata && geneMetadata.filename)) {
         setIsEmpty(false);
         setActiveTab(VARIANT_TYPES.genomic);
         setData(genomicVariants);

--- a/ui/src/components/admin/AdminView.js
+++ b/ui/src/components/admin/AdminView.js
@@ -12,7 +12,6 @@ import { ModelSingle } from './Model';
 
 import { AdminMain, AdminWrapper } from 'theme/adminStyles';
 
-import { VARIANT_IMPORT_STATUS } from 'utils/constants';
 import useInterval from 'utils/useInterval';
 import { isEmpty } from 'lodash';
 

--- a/ui/src/components/admin/Model/ModelVariants.js
+++ b/ui/src/components/admin/Model/ModelVariants.js
@@ -163,7 +163,6 @@ const getDateString = date => {
 export default ({ data: { name, gene_metadata, genomic_variants, variants, updatedAt } }) => {
   const importStatus = useRef(null);
   const { fetchGenomicVariantData } = useContext(ModelSingleContext);
-  const { appendNotification } = useContext(NotificationsContext);
   const [activeTab, setActiveTab] = useState(null);
   const {
     importNotifications,

--- a/ui/src/components/input/Toggle/Toggle.js
+++ b/ui/src/components/input/Toggle/Toggle.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { ToggleButton } from 'theme/searchStyles';
 
-export default ({ id, initialValue, onValueChange }) => {
+export default ({ id, initialValue, onValueChange, ...props }) => {
   const [toggleValue, setToggleValue] = useState(initialValue);
 
   const toggle = e => {
@@ -26,6 +26,7 @@ export default ({ id, initialValue, onValueChange }) => {
       aria-checked={toggleValue ? 'true' : 'false'}
       checked={toggleValue}
       onClick={toggle}
+      {...props}
     />
   );
 };

--- a/ui/src/components/input/Toggle/Toggle.js
+++ b/ui/src/components/input/Toggle/Toggle.js
@@ -17,7 +17,7 @@ export default ({ id, initialValue, onValueChange }) => {
 
   useEffect(() => {
     setToggleValue(initialValue);
-  }, []);
+  }, [initialValue]);
 
   return (
     <ToggleButton

--- a/ui/src/components/search/ExpandedToggle.js
+++ b/ui/src/components/search/ExpandedToggle.js
@@ -5,9 +5,12 @@ import Toggle from 'components/input/Toggle';
 
 import QuestionMarkIcon from 'icons/QuestionMarkIcon';
 
+import { useExpandedUnexpanded } from 'providers/ExpandedUnexpanded';
+
 import { getNumUnexpanded } from 'utils/sqonHelpers';
 
-const ExpandedToggle = ({ showUnexpanded, setShowUnexpanded }) => {
+const ExpandedToggle = () => {
+  const { showUnexpanded, setShowUnexpanded } = useExpandedUnexpanded();
   const [numUnexpanded, setNumUnexpanded] = useState('');
 
   useEffect(() => {

--- a/ui/src/components/search/ExpandedToggle.js
+++ b/ui/src/components/search/ExpandedToggle.js
@@ -25,6 +25,7 @@ const ExpandedToggle = ({ sqon }) => {
   return (
     <>
       <Toggle
+        disabled={numUnexpanded === 0}
         id="expanded-toggle"
         initialValue={showUnexpanded}
         onValueChange={() => setShowUnexpanded(!showUnexpanded)}

--- a/ui/src/components/search/ExpandedToggle.js
+++ b/ui/src/components/search/ExpandedToggle.js
@@ -9,18 +9,18 @@ import { useExpandedUnexpanded } from 'providers/ExpandedUnexpanded';
 
 import { getNumUnexpanded } from 'utils/sqonHelpers';
 
-const ExpandedToggle = () => {
+const ExpandedToggle = ({ sqon }) => {
   const { showUnexpanded, setShowUnexpanded } = useExpandedUnexpanded();
   const [numUnexpanded, setNumUnexpanded] = useState('');
 
   useEffect(() => {
     const fetchNumUnexpanded = async () => {
-      const data = await getNumUnexpanded();
+      const data = await getNumUnexpanded(sqon);
       setNumUnexpanded(data);
     };
 
-    fetchNumUnexpanded();
-  }, []);
+    fetchNumUnexpanded(sqon);
+  }, [sqon]);
 
   return (
     <>
@@ -38,7 +38,8 @@ const ExpandedToggle = () => {
           text-align: right;
         `}
       >
-        {showUnexpanded ? 'Hide' : 'Show'} {`${numUnexpanded} unexpanded models`}
+        {showUnexpanded ? 'Hide' : 'Show'}{' '}
+        {`${numUnexpanded} unexpanded model${numUnexpanded !== 1 ? 's' : ''}`}
       </label>
       <Popup
         trigger={() => (

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -46,7 +46,7 @@ export default ({
   version,
   ...props
 }) => {
-  const { showUnexpanded, setShowUnexpanded } = useExpandedUnexpanded();
+  const { showUnexpanded } = useExpandedUnexpanded();
 
   return (
     <>

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -239,7 +239,7 @@ export default ({
                           url: `${globals.ARRANGER_API}/export/${version}/models`,
                         })}
                         fieldTypesForFilter={['text', 'keyword', 'id']}
-                        customHeaderContent={<ExpandedToggle />}
+                        customHeaderContent={<ExpandedToggle sqon={filterExpanded(sqon)} />}
                       />
                     );
                   }}

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Component from 'react-component-component';
 import { Aggregations, CurrentSQON, Table } from '@arranger/components/dist/Arranger';
 import '@arranger/components/public/themeStyles/beagle/beagle.css';
@@ -26,6 +26,8 @@ import ShareButton from 'components/ShareButton';
 import ModelList from 'components/ModelList';
 import TextInput from 'components/TextInput';
 
+import { useExpandedUnexpanded } from 'providers/ExpandedUnexpanded';
+
 import globals from 'utils/globals';
 import { filterExpanded, toggleExpanded } from 'utils/sqonHelpers';
 
@@ -44,7 +46,7 @@ export default ({
   version,
   ...props
 }) => {
-  const [showUnexpanded, setShowUnexpanded] = useState(false);
+  const { showUnexpanded, setShowUnexpanded } = useExpandedUnexpanded();
 
   return (
     <>
@@ -237,12 +239,7 @@ export default ({
                           url: `${globals.ARRANGER_API}/export/${version}/models`,
                         })}
                         fieldTypesForFilter={['text', 'keyword', 'id']}
-                        customHeaderContent={
-                          <ExpandedToggle
-                            showUnexpanded={showUnexpanded}
-                            setShowUnexpanded={setShowUnexpanded}
-                          />
-                        }
+                        customHeaderContent={<ExpandedToggle />}
                       />
                     );
                   }}

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -40,7 +40,7 @@ export default ({
   setState,
   state,
   setSQON,
-  sqon = { op: 'and', content: [{ op: 'in', content: { field: 'expanded', value: ['true'] } }] },
+  sqon,
   savedSetsContext,
   history,
   version,

--- a/ui/src/providers/ExpandedUnexpanded.js
+++ b/ui/src/providers/ExpandedUnexpanded.js
@@ -1,0 +1,49 @@
+import React, { useContext, useState } from 'react';
+
+const SHOW_UNEXPANDED_KEY = 'show-unexpanded';
+
+export const ExpandedUnexpandedContext = React.createContext([{}, () => {}]);
+
+export const ExpandedUnexpandedProvider = props => {
+  const [showUnexpanded, setShowUnexpanded] = useState(
+    JSON.parse(localStorage.getItem(SHOW_UNEXPANDED_KEY)) || false,
+  );
+
+  return (
+    <ExpandedUnexpandedContext.Provider value={[[showUnexpanded, setShowUnexpanded]]}>
+      {props.children}
+    </ExpandedUnexpandedContext.Provider>
+  );
+};
+
+export const useExpandedUnexpanded = () => {
+  const [[showUnexpanded, setShowUnexpanded]] = useContext(ExpandedUnexpandedContext);
+
+  const get = () => {
+    if (typeof JSON.parse(localStorage.getItem(SHOW_UNEXPANDED_KEY)) === 'undefined') {
+      localStorage.setItem(SHOW_UNEXPANDED_KEY, false);
+    }
+
+    if (typeof showUnexpanded === 'undefined') {
+      setShowUnexpanded(false);
+    }
+
+    return JSON.parse(localStorage.getItem(SHOW_UNEXPANDED_KEY));
+  };
+
+  const set = val => {
+    setShowUnexpanded(val);
+    localStorage.setItem(SHOW_UNEXPANDED_KEY, val);
+  };
+
+  const clear = () => {
+    setShowUnexpanded(undefined);
+    localStorage.removeItem(SHOW_UNEXPANDED_KEY);
+  };
+
+  return {
+    showUnexpanded: get(),
+    setShowUnexpanded: set,
+    clearShowUnexpanded: clear,
+  };
+};

--- a/ui/src/providers/ExpandedUnexpanded.js
+++ b/ui/src/providers/ExpandedUnexpanded.js
@@ -28,7 +28,7 @@ export const useExpandedUnexpanded = () => {
       setShowUnexpanded(false);
     }
 
-    return JSON.parse(localStorage.getItem(SHOW_UNEXPANDED_KEY));
+    return showUnexpanded;
   };
 
   const set = val => {
@@ -36,14 +36,14 @@ export const useExpandedUnexpanded = () => {
     localStorage.setItem(SHOW_UNEXPANDED_KEY, val);
   };
 
-  const clear = () => {
-    setShowUnexpanded(undefined);
-    localStorage.removeItem(SHOW_UNEXPANDED_KEY);
+  const reset = () => {
+    setShowUnexpanded(false);
+    localStorage.setItem(SHOW_UNEXPANDED_KEY, false);
   };
 
   return {
     showUnexpanded: get(),
     setShowUnexpanded: set,
-    clearShowUnexpanded: clear,
+    resetShowUnexpanded: reset,
   };
 };

--- a/ui/src/theme/adminNotificationStyles.js
+++ b/ui/src/theme/adminNotificationStyles.js
@@ -1,6 +1,5 @@
 import styled, { keyframes } from 'react-emotion';
 import { css } from 'emotion';
-import { Link } from 'react-router-dom';
 import { Element } from 'react-scroll';
 
 import { NOTIFICATION_TYPES } from './../components/admin/Notifications';

--- a/ui/src/theme/searchStyles.js
+++ b/ui/src/theme/searchStyles.js
@@ -890,6 +890,7 @@ export const ToggleButton = styled('button')`
   cursor: pointer;
   background-color: ${({ checked }) => (checked ? pelorousapprox : bombay)} !important;
   transition: background-color 0.25s ease !important;
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)} !important;
 
   &::after {
     content: '';

--- a/ui/src/utils/sqonHelpers.js
+++ b/ui/src/utils/sqonHelpers.js
@@ -28,7 +28,7 @@ export const toggleExpanded = (sqon, showUnexpanded = false) => {
       );
 };
 
-export const getNumUnexpanded = async () => {
+export const getNumUnexpanded = async sqon => {
   const numUnexpanded = await api({
     endpoint: `/${globals.VERSION}/graphql`,
     body: {
@@ -41,7 +41,21 @@ export const getNumUnexpanded = async () => {
                 }
               `,
       variables: {
-        filters: { op: 'in', content: { field: 'expanded', value: ['false'] } },
+        filters: addInSQON(
+          {
+            op: 'and',
+            content: [
+              {
+                op: 'in',
+                content: {
+                  field: 'expanded',
+                  value: ['false'],
+                },
+              },
+            ],
+          },
+          sqon,
+        ),
       },
     },
   });


### PR DESCRIPTION
In order to replicate SQON functionality (i.e. persisting on refresh of search page, persisting on clicking "Back to Search" link on Model Details page header, resetting on clicking the HCMI logo in the main header), the state of the expanded/unexpanded toggle was moved to localStorage and can now be accessed using a shared context.

The count for the number of unexpanded models has also been updated to reflect changes that are applied to search.

The bug where clicking the "Back to Search" link in the Model Details page header would sometimes still show the expanded status in the SQON has also been fixed.

Commits:
- ✨ Persist toggle state on navigation and refresh (#697)
    * Move Expanded/Unexpanded toggle state to a shared context
    * Persist toggle state by storing it in localStorage
- 🐛 Reset expanded/unexpanded toggle state onClick of header logo prior to returning to search page
- 🐛 Update the number of unexpanded models to reflect applied filters
- 🐛 Hide expanded status from SQON in URL on Search page (#697)