### PR TITLE
♿️ Add "Skip to Main Content" skip nav link

### DIFF
--- a/ui/src/components/App.js
+++ b/ui/src/components/App.js
@@ -8,6 +8,7 @@ import globals from 'utils/globals';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { Dashboard as ArrangerDashboard } from '@arranger/components';
 
+import SkipNav from 'components/SkipNav';
 import SearchWrapper from 'components/search/SearchWrapper';
 import Model from 'components/Model';
 import Admin from 'components/admin';
@@ -40,6 +41,7 @@ const ProvidedRoutes = () => (
       >
         {({ state }) => (
           <ExpandedUnexpandedProvider>
+            <SkipNav />
             <Switch>
               <Route
                 path="/"

--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -264,7 +264,7 @@ export default ({ modelName }) => (
           : [],
       ),
     }) => (
-      <div css={styles}>
+      <main id="main" css={styles}>
         <ModelBar
           name={modelName}
           id={(queryState.model || { id: '' }).id}
@@ -458,7 +458,7 @@ export default ({ modelName }) => (
         )}
 
         <ModelCarouselBar name={modelName} className="model-carousel-bar--bottom" />
-      </div>
+      </main>
     )}
   </ModelQuery>
 );

--- a/ui/src/components/SkipNav.js
+++ b/ui/src/components/SkipNav.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { SkipNavWrapper, SkipNavLink } from 'theme/skipNavStyles';
+
+export default () => {
+  return (
+    <SkipNavWrapper>
+      <SkipNavLink href="#main">Skip to Main Content</SkipNavLink>
+    </SkipNavWrapper>
+  );
+};

--- a/ui/src/components/admin/AdminView.js
+++ b/ui/src/components/admin/AdminView.js
@@ -51,7 +51,7 @@ export default ({ location }) => {
   return (
     <AdminWrapper>
       <AdminNav location={location} />
-      <AdminMain>
+      <AdminMain id="main">
         <Route exact path="/admin" component={ModelsManager} />
         <Route exact path="/admin/model/:name?" component={ModelSingle} />
         <Route exact path="/admin/manage-users" component={UsersManager} />

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -31,7 +31,7 @@ import { useExpandedUnexpanded } from 'providers/ExpandedUnexpanded';
 import globals from 'utils/globals';
 import { filterExpanded, toggleExpanded } from 'utils/sqonHelpers';
 
-import searchStyles from 'theme/searchStyles';
+import searchStyles, { MainCol } from 'theme/searchStyles';
 import { Row, Col } from 'theme/system';
 
 let stable = true;
@@ -84,7 +84,8 @@ export default ({
               )}
             </Component>
           </Col>
-          <Col
+          <MainCol
+            id="main"
             className="search-results-wrapper"
             p={30}
             flex={1}
@@ -247,7 +248,7 @@ export default ({
               )}
             </Component>
             <LastUpdatedDate />
-          </Col>
+          </MainCol>
         </SplitPane>
       </Col>
     </>

--- a/ui/src/theme/adminStyles.js
+++ b/ui/src/theme/adminStyles.js
@@ -17,7 +17,7 @@ export const AdminWrapper = styled(Col)`
 export const AdminMain = styled(Row)`
   background: ${bkgColour};
   label: admin-main;
-`;
+`.withComponent('main');
 
 export const AdminContainer = styled(Col)`
   position: relative;

--- a/ui/src/theme/searchStyles.js
+++ b/ui/src/theme/searchStyles.js
@@ -8,6 +8,7 @@ import doubleChevron from 'assets/icon-chevron-double-down.svg';
 import base from 'theme';
 import { HEADER_HEIGHT } from 'theme/headerStyles';
 import { brandPrimaryHighlightHover, whiteButtonHover } from 'theme/hoverStyles';
+import { Col } from 'theme/system';
 
 const {
   fonts: { openSans },
@@ -914,3 +915,5 @@ export const ToggleButton = styled('button')`
     transition: left 0.25s ease !important;
   }
 `;
+
+export const MainCol = styled(Col)``.withComponent('main');

--- a/ui/src/theme/skipNavStyles.js
+++ b/ui/src/theme/skipNavStyles.js
@@ -1,0 +1,30 @@
+import styled from 'react-emotion';
+
+import base from 'theme';
+
+const {
+  keyedPalette: { black, linen, redDamask },
+} = base;
+
+export const SkipNavWrapper = styled('div')`
+  margin: 0;
+  padding: 0;
+`;
+
+export const SkipNavLink = styled('a')`
+  position: fixed;
+  top: -9999px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 16px;
+  background-color: ${linen};
+  border: 2px solid ${redDamask};
+  color: ${black};
+  text-decoration: none;
+  font-weight: bold;
+  z-index: 9999;
+
+  &:focus {
+    top: 16px;
+  }
+`;


### PR DESCRIPTION
Set the "main" content as the following:

Search page -> search results column
Model details page -> content immediately after header nav
Admin pages -> content immediately after admin nav

Link is visually hidden until it receives focus, clicking the link sets focus to the element designated as "main" above.