### PR TITLE
Modify genomic variant import and publish to use only MAF data

### DIFF
--- a/cms/src/helpers/genomicVariants.js
+++ b/cms/src/helpers/genomicVariants.js
@@ -92,6 +92,12 @@ export const addGenomicVariantsFromMaf = async (name, mafData, { filename, fileI
       const reference_allele = row.Reference_Allele;
       const tumor_allele = row.Tumor_Seq_Allele2;
 
+      // Properties originally from Reference that are temporarily taken from MAF - Jon Eubank 2020-09-29
+      const gene = row.Hugo_Symbol;
+      const gene_biotype = titleCase(row.BIOTYPE.replace(/_/g, ' '), i => !i.includes('RNA'));
+      const name = `${row.Hugo_Symbol} ${aa_change}`;
+      const synonyms = [];
+
       const variant_id = buildVariantId({
         chromosome,
         type,
@@ -115,8 +121,16 @@ export const addGenomicVariantsFromMaf = async (name, mafData, { filename, fileI
         classification,
         entrez_id,
         variant_id,
+        gene,
+        gene_biotype,
+        synonyms,
+        name,
       };
 
+      /* This section is the original code for defining the genomic variant data using the Gene Reference library.
+       *   This is removed because it was learned that the latest gene reference version is ahead of the GDC data
+       *   that we are importing. GDC plans to update their Gene Reference to match, so in the future this can be used again.
+       *   
       const geneReference = await Gene.findOne({ _gene_id: ensemble_id });
       if (geneReference) {
         variant.gene = geneReference.symbol;
@@ -138,6 +152,7 @@ export const addGenomicVariantsFromMaf = async (name, mafData, { filename, fileI
         variant.synonyms = [];
         variant.name = 'Unknown'; //row.Hugo_Symbol;
       }
+      */
 
       genomicVariants.push(variant);
     }

--- a/ui/src/components/search/GeneSearch.js
+++ b/ui/src/components/search/GeneSearch.js
@@ -13,11 +13,11 @@ export default ({ sqon, setSQON, ...props }) => (
     placeholder="e.g. BRAF, EWSR, ..."
     ResultsIcon={GeneIcon}
     optionTransformer={option => {
-      const details = [option.ensemble_id, option.name];
-      if (option.synonyms && option.synonyms.length > 0) {
-        details.push(option.synonyms.join(', '));
-      }
-
+      // const details = [option.ensemble_id, option.name];
+      // if (option.synonyms && option.synonyms.length > 0) {
+      //   details.push(option.synonyms.join(', '));
+      // }
+      const details = [option.ensemble_id];
       return { title: option.symbol, details, value: option.symbol };
     }}
     filterField="gene_metadata.genes"


### PR DESCRIPTION
This is an approach to handling the discrepancy in versions between our gene reference library version and that of the GDC variants we are importing. Instead of using the Gene Reference to populate details about genes, we will rely exclusively on data provided in the MAF. One immediate impact of this change is there will be no Gene Names (short text description) or synonyms available.

This modifies 3 pieces of code:
 - Variant Import will now populate fields from the MAF that were taken from gene reference (or leave them blank if not availble in MAF)
 - Search index publishing for genes and variants will rely solely on the published variant data, it will not supplement the gene documents with any data from the Gene Reference 
 - The Gene text search display will remove synonyms and names from each suggested record since these will always be empty under this scheme.