### PR TITLE
🐛 Fix 'Other' Type in Growth Chart (#686)

### DIFF
--- a/ui/src/components/charts/GrowthChart.js
+++ b/ui/src/components/charts/GrowthChart.js
@@ -1,17 +1,19 @@
-/* eslint-disable */
 import React from 'react';
-import { groupBy, sumBy } from 'lodash';
 import { ResponsivePie } from '@nivo/pie';
 import AggregationQuery from 'components/queries/AggregationQuery';
-import TwoDIcon from 'icons/TwoDIcon';
-import ThreeDIcon from 'icons/ThreeDIcon';
 import { Col } from 'theme/system';
 import theme from 'theme';
 import { ChartTooltip } from './';
 import { addInSQON } from '@arranger/components/dist/SQONView/utils';
 import { SizeMe } from 'react-sizeme';
 
-const HAS_LABELS_WIDTH = 320;
+const is2d = bucket => bucket.key.slice(0, 3) === '2-D';
+const is3d = bucket => bucket.key.slice(0, 3) === '3-D';
+const isOther = bucket => bucket.key.match(/^[A-Z]/i);
+const getCount = (buckets, filterBy) =>
+  buckets.filter(filterBy).reduce((acc, curr) => acc + curr.doc_count, 0);
+const getKeys = (buckets, filterBy) => buckets.filter(filterBy).map(x => x.key);
+
 export default ({ sqon, setSQON }) => (
   <SizeMe>
     {({ size }) => (
@@ -24,63 +26,35 @@ export default ({ sqon, setSQON }) => (
           padding: 12px 0 4px;
         `}
       >
-        <span className="sqon-field sqon-field--chart-title">
-          2D versus 3D Growth
-        </span>
+        <span className="sqon-field sqon-field--chart-title">2D versus 3D Growth</span>
         <AggregationQuery sqon={sqon} field="type">
           {({
             state,
-            data = Object.entries(groupBy(state.buckets || [], x => x.key.slice(0, 3))).map(
-              ([k, v]) => ({
-                id: k,
-                value: sumBy(v, x => x.doc_count),
-                label: `${k === 'Oth' ? 'Other' : k} Growth`,
-                keys: v.map(x => x.key),
-              }),
-            ),
+            data = [
+              {
+                id: '2-D',
+                value: getCount(state.buckets || [], is2d),
+                label: '2-D Growth',
+                keys: getKeys(state.buckets || [], is2d),
+              },
+              {
+                id: '3-D',
+                value: getCount(state.buckets || [], is3d),
+                label: '3-D Growth',
+                keys: getKeys(state.buckets || [], is3d),
+              },
+              {
+                id: 'Other',
+                value: getCount(state.buckets || [], isOther),
+                label: 'Other Growth',
+                keys: getKeys(state.buckets || [], isOther),
+              },
+            ],
           }) => {
             return state.loading ? (
               'loading'
             ) : (
               <>
-                {/* {size.width > HAS_LABELS_WIDTH && (
-                  <Col
-                    css={`
-                      position: absolute;
-                      top: 50%;
-                      left: 10%;
-                      display: flex;
-                      flex-direction: column;
-                      align-items: center;
-                    `}
-                  >
-                    <TwoDIcon
-                      alt="2d growth"
-                      css={`
-                        fill: ${theme.growthChartPalette[1]};
-                      `}
-                    />
-                    <span
-                      css={`
-                        margin-top: 4px;
-                        font-weight: bold;
-                        color: ${theme.growthChartPalette[1]};
-                      `}
-                    >
-                      2D:
-                      {Math.round(
-                        (Object.entries(groupBy(state.buckets, x => x.key.slice(0, 3)))
-                          .map(([k, v]) => ({
-                            key: k,
-                            total: sumBy(v, x => x.doc_count),
-                          }))
-                          .find(x => x.key === '2-D')?.total || 0) /
-                          state.total *
-                          100, //eslint-disable-line
-                      )}%
-                    </span>
-                  </Col>
-                )} */}
                 <ResponsivePie
                   margin={{
                     top: 12,
@@ -92,7 +66,7 @@ export default ({ sqon, setSQON }) => (
                   data={[
                     data.find(({ id }) => id === '3-D') || { id: '3-D', value: 0 },
                     data.find(({ id }) => id === '2-D') || { id: '2-D', value: 0 },
-                    data.find(({ id }) => !['3-D','2-D'].includes(id)) || { id: 'Other', value: 0 },
+                    data.find(({ id }) => id === 'Other') || { id: 'Other', value: 0 },
                   ]}
                   colors={theme.growthChartPalette}
                   innerRadius={0.7}
@@ -122,50 +96,12 @@ export default ({ sqon, setSQON }) => (
                     )
                   }
                   onMouseEnter={(_data, event) => {
-                    event.currentTarget.style.cursor = 'pointer'
+                    event.currentTarget.style.cursor = 'pointer';
                   }}
                   onMouseLeave={(_data, event) => {
-                    event.currentTarget.style.cursor = 'auto'
+                    event.currentTarget.style.cursor = 'auto';
                   }}
                 />
-                {/* {size.width > HAS_LABELS_WIDTH && (
-                  <Col
-                    css={`
-                      position: absolute;
-                      top: 50%;
-                      right: 10%;
-                      display: flex;
-                      flex-direction: column;
-                      align-items: center;
-                    `}
-                  >
-                    <ThreeDIcon
-                      alt="3d growth"
-                      css={`
-                        fill: ${theme.growthChartPalette[0]};
-                      `}
-                    />
-                    <span
-                      css={`
-                        margin-top: 4px;
-                        font-weight: bold;
-                        color: ${theme.growthChartPalette[0]};
-                      `}
-                    >
-                      3D:
-                      {Math.round(
-                        (Object.entries(groupBy(state.buckets, x => x.key.slice(0, 3)))
-                          .map(([k, v]) => ({
-                            key: k,
-                            total: sumBy(v, x => x.doc_count),
-                          }))
-                          .find(x => x.key === '3-D')?.total || 0) /
-                          state.total *
-                          100,
-                      )}%
-                    </span>
-                  </Col>
-                )} */}
               </>
             );
           }}


### PR DESCRIPTION
* Rewrite how data for Growth Chart is grouped to allow for grouping non-2-D-or-3-D into 'Other' properly
* Re-enable linter in Growth Chart, apply linter fixes
* Remove 2+ year old unused code, remove lodash dependency