### PR TITLE
✨ Update Bulk Model Upload Modal for Bulk Variant Import (#848)

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -29,7 +29,7 @@
     "googleapis": "59",
     "helmet": "^3.15.0",
     "json2csv": "^4.2.1",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.21",
     "map-stream": "^0.0.7",
     "method-override": "^2.3.10",
     "mongoose": "^5.7.5",

--- a/cms/src/routes/genomicVariants.js
+++ b/cms/src/routes/genomicVariants.js
@@ -112,7 +112,7 @@ variantsRouter.post('/import/bulk', async (req, res) => {
       return res.status(400).json({ success: false, error: result.error });
     }
 
-    return res.status(200).json({ succes: true, startTime: result.startTime });
+    return res.status(200).json({ success: true, startTime: result.startTime });
   } catch (error) {
     logger.error(error, `Error occurred during bulk MAF import`);
     res.status(500).json({

--- a/cms/src/routes/genomicVariants.js
+++ b/cms/src/routes/genomicVariants.js
@@ -207,6 +207,32 @@ variantsRouter.get('/audit', async (req, res) => {
   }
 });
 
+variantsRouter.post('/audit', async (req, res) => {
+  const { models } = req.body;
+
+  try {
+    logger.debug(`Performing a genomic variant audit for select models...`);
+    let imported = [];
+    let clean = [];
+
+    for (let i = 0; i < models.length; i++) {
+      const model = await Model.findOne({ name: models[i] });
+      if (model.genomic_variants && model.genomic_variants.length) {
+        imported.push(models[i]);
+      } else {
+        clean.push(models[i]);
+      }
+    }
+
+    return res.status(200).json({ imported, clean });
+  } catch (error) {
+    logger.error(error, `Error occurred during genomic variant audit`);
+    res.status(500).json({
+      error: error,
+    });
+  }
+});
+
 variantsRouter.post('/acknowledge/bulk', async (req, res) => {
   const { models } = req.body;
 

--- a/cms/src/services/gdc-importer/gdcConstants.js
+++ b/cms/src/services/gdc-importer/gdcConstants.js
@@ -18,6 +18,12 @@ export const IMPORT_ERRORS = {
   unexpected: 'UNEXPECTED',
 };
 
+export const IMPORT_OVERWRITE_OPTIONS = {
+  cleanOnly: 'CLEAN_ONLY',
+  allModels: 'ALL_MODELS',
+  none: 'NONE',
+};
+
 export const GDC_NORMAL_SAMPLE_TYPES = [
   'Blood Derived Normal',
   'Solid Tissue Normal',

--- a/data_model/package.json
+++ b/data_model/package.json
@@ -24,10 +24,10 @@
     "yargs": "^11.0.0"
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
     "@elastic/elasticsearch": "^7.5.0",
+    "babel-polyfill": "^6.26.0",
     "faker": "^4.1.0",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.21",
     "omit-deep": "^0.3.0",
     "ora": "^2.1.0",
     "randexp": "^0.4.9",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,7 @@
     "encodeurl": "^1.0.2",
     "filesaver.js": "^1.3.4",
     "formik": "^1.0.1",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.21",
     "moment-timezone": "^0.5.23",
     "prop-types": "^15.6.2",
     "query-string": "5.1.0",

--- a/ui/src/components/admin/BulkUpload/BulkUploadInput.js
+++ b/ui/src/components/admin/BulkUpload/BulkUploadInput.js
@@ -21,6 +21,8 @@ import ExportIcon from 'icons/ExportIcon';
 import ExternalLinkIcon from 'icons/ExternalLinkIcon';
 import googleSheetsLogo from 'assets/logo-googlesheets.png';
 
+import { BULK_UPLOAD_TYPES, VARIANT_OVERWRITE_OPTIONS } from 'utils/constants';
+
 const normalizeOption = option => (option === 'true' ? true : option === 'false' ? false : option);
 
 // Map simple string/number options to keyed objects
@@ -36,6 +38,12 @@ const overwriteOptions = type => [
   { label: `Yes, overwrite existing ${type}s`, value: true },
 ];
 
+const variantOverwriteOptions = [
+  { label: 'Yes, but only for models with no research somatic variant data.', value: VARIANT_OVERWRITE_OPTIONS.cleanOnly },
+  { label: 'Yes, for all models in this sheet.', value: VARIANT_OVERWRITE_OPTIONS.allModels },
+  { label: 'No, do not import any research somatic variant data.', value: VARIANT_OVERWRITE_OPTIONS.none },
+];
+
 export default ({
   type,
   displayType,
@@ -43,7 +51,9 @@ export default ({
   sheetsURL,
   backupURL,
   overwrite,
+  overwriteVariants,
   onOverwriteChange,
+  onOverwriteVariantsChange,
   signedIn,
 }) => {
   const [templateUrl, setTemplateUrl] = useState(null);
@@ -154,6 +164,37 @@ export default ({
           </RadioSelect>
         </UploadOverwrite>
       </BulkUploadContentBlock>
+      {type === BULK_UPLOAD_TYPES.MODEL && <BulkUploadContentBlock>
+        <UploadOverwrite>
+          <UploadContentHeading>
+            {`Would you like to overwrite the existing research somatic variants for the ${displayType || type}s within this google sheet?`}
+          </UploadContentHeading>
+          <RadioSelect>
+            {variantOverwriteOptions.map((option, idx) => {
+              let formValue = normalizeOption(overwriteVariants);
+              const optionValue = normalizeOption(option.value);
+              return (
+                <label key={idx} htmlFor={`overwrite-variants-option-${idx}`}>
+                  {option.label}
+                  <input
+                    type="radio"
+                    id={`overwrite-variants-option-${idx}`}
+                    value={optionValue}
+                    checked={formValue === optionValue}
+                    onChange={e => {
+                      onOverwriteVariantsChange(e.currentTarget.value);
+                    }}
+                    onClick={e => {
+                      onOverwriteVariantsChange(e.currentTarget.value);
+                    }}
+                  />
+                  <span />
+                </label>
+              );
+            })}
+          </RadioSelect>
+        </UploadOverwrite>
+      </BulkUploadContentBlock>}
     </BulkUploadContent>
   );
 };

--- a/ui/src/components/admin/BulkUpload/BulkUploadModal.js
+++ b/ui/src/components/admin/BulkUpload/BulkUploadModal.js
@@ -8,6 +8,8 @@ import BulkUploadInput from './BulkUploadInput';
 import { ButtonPill } from 'theme/adminControlsStyles';
 import { ModalWrapper, Header, Title, CloseModal, Content, Footer } from 'theme/adminModalStyles';
 
+import { VARIANT_OVERWRITE_OPTIONS } from 'utils/constants';
+
 const BulkUploadModal = ({ type, displayType, onUpload, backupURL, ...props }) => {
   const didMountRef = useRef(false);
   let modalState = useContext(ModalStateContext);
@@ -16,16 +18,18 @@ const BulkUploadModal = ({ type, displayType, onUpload, backupURL, ...props }) =
   // eslint-disable-next-line no-unused-vars
   let [uploadResults, setUploadResults] = useState({});
   let [overwrite, setOverwrite] = useState(false);
+  let [overwriteVariants, setOverwriteVariants] = useState(VARIANT_OVERWRITE_OPTIONS.cleanOnly);
   const [signedIn, setSignedIn] = useState(false);
 
   const onSheetsURLChange = newURL => setSheetsURL(newURL);
   const onUploadClick = () => setUploadingGoogleSheet(true);
   const onOverwriteChange = value => setOverwrite(value);
+  const onOverwriteVariantsChange = value => setOverwriteVariants(value);
 
   const didUpdate = async () => {
     try {
       if (uploadingGoogleSheet) {
-        const uploadSheetResult = await onUpload(sheetsURL, overwrite);
+        const uploadSheetResult = await onUpload(sheetsURL, overwrite, overwriteVariants);
 
         await setUploadingGoogleSheet(false);
         await setUploadResults(uploadSheetResult);
@@ -75,7 +79,9 @@ const BulkUploadModal = ({ type, displayType, onUpload, backupURL, ...props }) =
             type,
             displayType,
             overwrite,
+            overwriteVariants,
             onOverwriteChange,
+            onOverwriteVariantsChange,
             signedIn,
           }}
           {...props}

--- a/ui/src/components/admin/Model/ModelVariants.js
+++ b/ui/src/components/admin/Model/ModelVariants.js
@@ -26,7 +26,12 @@ import { Table, ToolbarHeader } from 'theme/adminTableStyles';
 import { AdminModalStyle } from 'theme/adminModalStyles';
 
 import config from '../config';
-import { VARIANT_IMPORT_STATUS, VARIANT_TYPES } from 'utils/constants';
+import {
+  BULK_UPLOAD_TYPES,
+  BULK_UPLOAD_DISPLAY_TYPES,
+  VARIANT_IMPORT_STATUS,
+  VARIANT_TYPES,
+} from 'utils/constants';
 
 const TabView = ({
   activeTab,
@@ -235,8 +240,8 @@ export default ({ data: { name, gene_metadata, genomic_variants, variants, updat
                           modalState.setModalState({
                             component: (
                               <BulkUploader
-                                type={'variant'}
-                                displayType={'clinical variant'}
+                                type={BULK_UPLOAD_TYPES.VARIANT}
+                                displayType={BULK_UPLOAD_DISPLAY_TYPES.VARIANT}
                                 onUpload={(sheetsURL, overwrite) =>
                                   attachVariants(sheetsURL, overwrite, name)
                                 }

--- a/ui/src/components/admin/Model/actions/GenomicVariants.js
+++ b/ui/src/components/admin/Model/actions/GenomicVariants.js
@@ -57,6 +57,26 @@ export const importGenomicVariants = async modelName => {
   return post({ url });
 };
 
+export const importBulkGenomicVariants = async models => {
+  const url = `${GENOMIC_VARIANTS_URL}/import/bulk`;
+  return post({
+    url,
+    data: {
+      models
+    },
+  });
+};
+
+export const checkGenomicVariants = async models => {
+  const url = `${GENOMIC_VARIANTS_URL}/audit`;
+  return post({
+    url,
+    data: {
+      models
+    },
+  });
+}
+
 export const clearGenomicVariants = async modelName => {
   return new Promise(async (resolve, reject) => {
     const url = `${GENOMIC_VARIANTS_URL}/clear/${modelName}`;

--- a/ui/src/components/admin/ModelsManager/ModelsManager.js
+++ b/ui/src/components/admin/ModelsManager/ModelsManager.js
@@ -16,6 +16,7 @@ import { Table } from 'theme/adminTableStyles';
 import { AdminModalStyle } from 'theme/adminModalStyles';
 
 import config from '../config';
+import { BULK_UPLOAD_TYPES } from 'utils/constants';
 
 const content = () => {
   return (
@@ -36,7 +37,7 @@ const content = () => {
                         modalState.setModalState({
                           component: (
                             <BulkUploader
-                              type={'model'}
+                              type={BULK_UPLOAD_TYPES.MODEL}
                               onUpload={uploadModelsFromSheet}
                               backupURL={`${config.urls.cmsBase}/bulk/backup`}
                             />

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -1,3 +1,13 @@
+const BULK_UPLOAD_TYPES = {
+  MODEL: 'model',
+  VARIANT: 'variant',
+};
+
+const BULK_UPLOAD_DISPLAY_TYPES = {
+  MODEL: 'model',
+  VARIANT: 'clinical variant',
+};
+
 const imgPath = '/api/data/images';
 
 const VARIANT_TYPES = {
@@ -13,4 +23,17 @@ const VARIANT_IMPORT_STATUS = {
   stopped: 'STOPPED',
 };
 
-export { imgPath, VARIANT_TYPES, VARIANT_IMPORT_STATUS };
+const VARIANT_OVERWRITE_OPTIONS = {
+  cleanOnly: 'CLEAN_ONLY',
+  allModels: 'ALL_MODELS',
+  none: 'NONE',
+};
+
+export {
+  BULK_UPLOAD_DISPLAY_TYPES,
+  BULK_UPLOAD_TYPES,
+  imgPath,
+  VARIANT_IMPORT_STATUS,
+  VARIANT_OVERWRITE_OPTIONS,
+  VARIANT_TYPES,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,15 +3545,15 @@ browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.1.1:
     node-releases "^1.1.23"
 
 browserslist@^4.12.0, browserslist@^4.8.5:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.0.tgz#410277627500be3cb28a1bfe037586fbedf9488b"
-  integrity sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==
+  version "4.16.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
+  integrity sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==
   dependencies:
-    caniuse-lite "^1.0.30001165"
+    caniuse-lite "^1.0.30001181"
     colorette "^1.2.1"
-    electron-to-chromium "^1.3.621"
+    electron-to-chromium "^1.3.649"
     escalade "^3.1.1"
-    node-releases "^1.1.67"
+    node-releases "^1.1.70"
 
 bser@2.1.1:
   version "2.1.1"
@@ -3805,10 +3805,10 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000887, caniuse-lite@^1.0.30000974:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
   integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
 
-caniuse-lite@^1.0.30000884, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001165:
-  version "1.0.30001173"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz#3c47bbe3cd6d7a9eda7f50ac016d158005569f56"
-  integrity sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==
+caniuse-lite@^1.0.30000884, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001181:
+  version "1.0.30001208"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz#a999014a35cebd4f98c405930a057a0d75352eb9"
+  integrity sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -5469,10 +5469,15 @@ elasticsearch@^16.6.0:
     chalk "^1.0.0"
     lodash "^4.17.10"
 
-electron-to-chromium@^1.3.150, electron-to-chromium@^1.3.62, electron-to-chromium@^1.3.621:
+electron-to-chromium@^1.3.150:
   version "1.3.634"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.634.tgz#82ea400f520f739c4f6ff00c1f7524827a917d25"
   integrity sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw==
+
+electron-to-chromium@^1.3.62, electron-to-chromium@^1.3.649:
+  version "1.3.711"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.711.tgz#92c3caf7ffed5e18bf63f66b4b57b4db2409c450"
+  integrity sha512-XbklBVCDiUeho0PZQCjC25Ha6uBwqqJeyDhPLwLwfWRAo4x+FZFsmu1pPPkXT+B4MQMQoQULfyaMltDopfeiHQ==
 
 element-resize-detector@^1.2.1:
   version "1.2.1"
@@ -10041,10 +10046,15 @@ lodash@4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-"lodash@>=3.5 <5", lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.19, lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -10906,7 +10916,12 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.0.0-alpha.11, node-releases@^1.1.23, node-releases@^1.1.67:
+node-releases@^1.0.0-alpha.11, node-releases@^1.1.70:
+  version "1.1.71"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
+  integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
+
+node-releases@^1.1.23:
   version "1.1.69"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.69.tgz#3149dbde53b781610cd8b486d62d86e26c3725f6"
   integrity sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==


### PR DESCRIPTION
Adds radio selection for "overwrite variants" option on Bulk Model Upload modal. Depending on the user's selection, this will trigger a bulk variant import for none/some/all of the models in the bulk upload Google sheet.

### Commits:
⬆️ Upgrade lodash
* Upgrade lodash from 4.17.19 to 4.17.21

✏️ Fix typo in bulk import response

✨ Add specific model genomic variant audit functionality
* Add POST endpoint to CMS for auditing specific models for genomic variants

✨ Allow for automatic variant imports after bulk model upload (#848)
* Update bulk model upload modal to allow the user to select whether or not they want to import variants for the models within the sheet
* Refactor bulk upload modal to use constants for bulk upload types
* Add front-end API calls for bulk variant import and genomic variant audit