### PR TITLE
✨ Add Show/Hide Button for Long Notification Lists (#855)

### DIFF
--- a/cms/src/services/gdc-importer/VariantImporter.js
+++ b/cms/src/services/gdc-importer/VariantImporter.js
@@ -373,7 +373,7 @@ const VariantImporter = (function() {
         }),
       ),
       // Actionable errors (multiple ngcm, no ngcm)
-      ...modelsStatus[GDC_MODEL_STATES.multipleNgcm].map(async modelName =>
+      ...(await Promise.all(modelsStatus[GDC_MODEL_STATES.multipleNgcm].map(async modelName =>
         Import({
           modelName,
           status: ImportStatus.error,
@@ -386,8 +386,8 @@ const VariantImporter = (function() {
           importType: ImportTypes.bulk,
           tissueStatus: await getTissueStatus(modelName),
         }),
-      ),
-      ...modelsStatus[GDC_MODEL_STATES.noNgcm].map(async modelName =>
+      ))),
+      ...(await Promise.all(modelsStatus[GDC_MODEL_STATES.noNgcm].map(async modelName =>
         Import({
           modelName,
           status: ImportStatus.error,
@@ -400,7 +400,7 @@ const VariantImporter = (function() {
           importType: ImportTypes.bulk,
           tissueStatus: await getTissueStatus(modelName),
         }),
-      ),
+      ))),
     ];
 
     // Queue imports for conflict-free models (single NGCM, single NGCM+)

--- a/ui/src/components/admin/Notifications/NotificationToaster.js
+++ b/ui/src/components/admin/Notifications/NotificationToaster.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import Component from 'react-component-component';
 import { scroller } from 'react-scroll';
 import Spinner from 'react-spinkit';
@@ -21,6 +21,9 @@ import {
   ErrorLabel,
   ErrorText,
   closeIcon,
+  ShowHideButton,
+  ShowHideButtonLabel,
+  PlusMinusIcon,
 } from 'theme/adminNotificationStyles';
 import { Col } from 'theme/system';
 import base from 'theme';
@@ -92,6 +95,7 @@ const renderIcon = type => {
 
 export default () => {
   const { notifications, clearNotification } = useContext(NotificationsContext);
+  const [showMore, setShowMore] = useState(false);
 
   return (
     <Component
@@ -104,7 +108,7 @@ export default () => {
       }}
     >
       <NotificationsToaster name="notifications-toaster">
-        {notifications.slice(0).reverse().map(notification => (
+        {notifications.slice(notifications.length > 5 && !showMore ? notifications.length - 5 : 0).reverse().map(notification => (
           <Notification key={notification.id} type={notification.type}>
             {renderIcon(notification.type)}
             <Col width={'100%'}>
@@ -157,6 +161,21 @@ export default () => {
             )}
           </Notification>
         ))}
+        {notifications.length > 5 && (
+          <ShowHideButton onClick={() => setShowMore(!showMore)}>
+            <PlusMinusIcon showMore={showMore}>
+              {showMore ? '-' : '+'}
+            </PlusMinusIcon>
+            <ShowHideButtonLabel>
+              {`${showMore ? 'Hide' : 'Show'} ${notifications.length - 5} ${
+                showMore
+                  ? notifications.length - 5 === 1 ? 'notification' : 'notifications'
+                  : 'more'
+                }`
+              }
+            </ShowHideButtonLabel>
+          </ShowHideButton>
+        )}
       </NotificationsToaster>
     </Component>
   );

--- a/ui/src/components/modals/ConfirmMafFileModal.js
+++ b/ui/src/components/modals/ConfirmMafFileModal.js
@@ -99,18 +99,31 @@ const ConfirmMafFileModal = ({
       const entity = getCancerModelEntity(file.entities);
       return {
         selection: (
-          <input
-            type="radio"
-            id={`confirm-maf-${file.fileId}`}
-            value={file.fileId}
-            checked={fileSelection.fileId === file.fileId}
-            onChange={e => {
-              onFileSelectionChange(e.currentTarget.value);
+          <label
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              width: '100%',
+              height: '100%',
+              cursor: 'pointer',
             }}
-            onClick={e => {
-              onFileSelectionChange(e.currentTarget.value);
-            }}
-          />
+            htmlFor={`confirm-maf-${file.fileId}`}
+            aria-label={`Select file ${file.filename}`}
+          >
+            <input
+              type="radio"
+              id={`confirm-maf-${file.fileId}`}
+              value={file.fileId}
+              checked={fileSelection.fileId === file.fileId}
+              onChange={e => {
+                onFileSelectionChange(e.currentTarget.value);
+              }}
+              onClick={e => {
+                onFileSelectionChange(e.currentTarget.value);
+              }}
+              style={{ cursor: 'pointer' }}
+            />
+          </label>
         ),
         filename: <MessageLink href={`${GDC_FILE_PAGE_URL_BASE}/${file.fileId}`} target="_blank" rel="noopener noreferrer">{file.filename}</MessageLink>,
         sampleType: entity.sampleType,

--- a/ui/src/theme/adminNotificationStyles.js
+++ b/ui/src/theme/adminNotificationStyles.js
@@ -10,7 +10,7 @@ import { Col, Row } from 'theme/system';
 
 const {
   fonts: { openSans },
-  keyedPalette: { aquaSpring, black, bombay, cinderella, mauvelous, morningGlory, yellowOrange },
+  keyedPalette: { aquaSpring, black, bombay, cinderella, cinnabar, mauvelous, morningGlory, stiletto, white, yellowOrange },
   transparency: { yellowOrange20 },
 } = base;
 
@@ -156,4 +156,42 @@ export const NotificationTableHeaderCol = styled(Col)`
   &:last-child {
     padding-left: 16px;
   }
+`;
+
+export const ShowHideButton = styled('button')`
+  border: none;
+  background: none;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: fit-content;
+  margin: 0 auto;
+  font-family: ${openSans};
+  font-size: 12px;
+  font-weight: bold;
+  line-height: normal;
+  text-align: center;
+`;
+
+export const ShowHideButtonLabel = styled('span')`
+  color: ${stiletto};
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const PlusMinusIcon = styled('span')`
+  color: ${white};
+  background: ${cinnabar};
+  border-radius: 100%;
+  width: 12px;
+  height: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  margin-right: 4px;
+  ${({ showMore }) => showMore && 'padding-bottom: 2px;'}
 `;


### PR DESCRIPTION
Feature work for #855 to add the `Show X more/Hide X notification(s)` button when there are 5+ notifications on screen.

Also includes a fix for a bug that was causing actionable errors in bulk imports to be created incorrectly, and a quality of life enhancement to the Confirm MAF File table.

### Commits
---
**🐛 Fix bulk import actionable errors async issue**
* Wait for `getTissueStatus` promise before spreading bulk imports onto failed list

**✨ Add Show/Hide Button for Long Notification Lists (#855)**
* Display only the 5 most recent notifications, unless the user clicks the toggle to show/hide more

**💄 Make MAF Files Easier to Select**
* Increase clickable area for Confirm MAF File radio buttons, center button in table column