### PR TITLE
✨ Add Import Progress Banner and Stop Import Button (#849 #856)

### DIFF
--- a/cms/src/services/gdc-importer/VariantImporter.js
+++ b/cms/src/services/gdc-importer/VariantImporter.js
@@ -186,13 +186,13 @@ const VariantImporter = (function() {
   let running = false;
 
   const cleanLists = () => {
-    failed = failed.filter(i => !i.getData().acknowledged);
-    stopped = stopped.filter(i => !i.getData().acknowledged);
-    success = success.filter(i => !i.getData().acknowledged);
+    failed = failed.filter(i => i && i.getData && !i.getData().acknowledged);
+    stopped = stopped.filter(i => i && i.getData && !i.getData().acknowledged);
+    success = success.filter(i => i && i.getData && !i.getData().acknowledged);
 
     // queue should never have anything acknowledged (should move to failed/stopped/success)
     // clearing just in case
-    queue = queue.filter(i => !i.getData().acknowledged);
+    queue = queue.filter(i => i && i.getData && !i.getData().acknowledged);
   };
 
   const emptyQueue = () => {
@@ -437,11 +437,11 @@ const VariantImporter = (function() {
   const stopImport = async modelName => {
     // In case we get into an invalid state with multiple imports for a given model name,
     //   we'll use filter to get the whole list of them.
-    const targets = queue.filter(i => i.modelName === modelName);
+    const targets = queue.filter(i => i && i.modelName === modelName);
     if (targets.length) {
       targets.forEach(target => target.stop());
       stopped = [...stopped, ...targets];
-      queue = queue.filter(i => i.modelName !== modelName);
+      queue = queue.filter(i => i && i.modelName !== modelName);
     }
 
     cleanLists();
@@ -477,9 +477,9 @@ const VariantImporter = (function() {
 
   const acknowledge = modelName => {
     const targets = [
-      ...failed.filter(i => i.modelName === modelName),
-      ...stopped.filter(i => i.modelName === modelName),
-      ...success.filter(i => i.modelName === modelName),
+      ...failed.filter(i => i && i.modelName === modelName),
+      ...stopped.filter(i => i && i.modelName === modelName),
+      ...success.filter(i => i && i.modelName === modelName),
     ];
     if (targets.length) {
       targets.forEach(target => target.acknowledge());
@@ -496,9 +496,9 @@ const VariantImporter = (function() {
     modelNames.forEach(modelName => {
       targets = [
         ...targets,
-        ...failed.filter(i => i.modelName === modelName),
-        ...stopped.filter(i => i.modelName === modelName),
-        ...success.filter(i => i.modelName === modelName),
+        ...failed.filter(i => i && i.modelName === modelName),
+        ...stopped.filter(i => i && i.modelName === modelName),
+        ...success.filter(i => i && i.modelName === modelName),
       ];
     });
 

--- a/ui/src/components/admin/AdminView.js
+++ b/ui/src/components/admin/AdminView.js
@@ -51,7 +51,7 @@ export default ({ location }) => {
           showImportStatusCheckError(error);
         });
     },
-    importRunning || !isEmpty(importNotifications) ? 1000 : null,
+    importRunning || !isEmpty(importNotifications) ? 500 : null,
   );
 
   return (

--- a/ui/src/components/admin/AdminView.js
+++ b/ui/src/components/admin/AdminView.js
@@ -21,7 +21,7 @@ export default ({ location }) => {
     importNotifications,
     importRunning,
     updateNotificationsFromStatus,
-    showImportStatusCheckError,
+    showUnexpectedImportError,
   } = useGenomicVariantImportNotifications();
 
   // Check for active genomic variant imports on page load
@@ -31,7 +31,7 @@ export default ({ location }) => {
         .then(importStatus => {
           updateNotificationsFromStatus(importStatus);
         }).catch(error => {
-          showImportStatusCheckError(error);
+          showUnexpectedImportError(error);
         });
     };
 
@@ -48,7 +48,7 @@ export default ({ location }) => {
         .then(importStatus => {
           updateNotificationsFromStatus(importStatus);
         }).catch(error => {
-          showImportStatusCheckError(error);
+          showUnexpectedImportError(error);
         });
     },
     importRunning || !isEmpty(importNotifications) ? 500 : null,

--- a/ui/src/components/admin/Model/actions/GenomicVariants.js
+++ b/ui/src/components/admin/Model/actions/GenomicVariants.js
@@ -111,3 +111,16 @@ export const resolveMafFileConflict = async (modelName, fileId, filename) => {
     });
   });
 };
+
+export const stopAllImports = async () => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${GENOMIC_VARIANTS_URL}/stop/all`;
+    await post({ url })
+      .then(res => {
+        resolve(res.data);
+      })
+      .catch(err => {
+        reject(err.response ? err.response.data.error : err);
+      });
+  });
+};

--- a/ui/src/components/admin/ModelsManager/ModelManagerController.js
+++ b/ui/src/components/admin/ModelsManager/ModelManagerController.js
@@ -223,7 +223,7 @@ export default ({ baseUrl, cmsBase, children, ...props }) => (
                             .catch(async error => {
                               await appendNotification({
                                 type: NOTIFICATION_TYPES.ERROR,
-                                message: error.response ? error.response.data.error.code : 'Bulk Import of Research Somatic Variants Failed.',
+                                message: 'Bulk Import of Research Somatic Variants Failed.',
                                 details: error.response ? error.response.data.error.message : error.message,
                                 timeout: false,
                               });
@@ -244,7 +244,7 @@ export default ({ baseUrl, cmsBase, children, ...props }) => (
                             .catch(async error => {
                               await appendNotification({
                                 type: NOTIFICATION_TYPES.ERROR,
-                                message: error.response ? error.response.data.error.code : 'Bulk Import of Research Somatic Variants Failed.',
+                                message: 'Bulk Import of Research Somatic Variants Failed.',
                                 details: error.response ? error.response.data.error.message : error.message,
                                 timeout: false,
                               });
@@ -283,7 +283,7 @@ export default ({ baseUrl, cmsBase, children, ...props }) => (
                   .catch(async error => {
                     await appendNotification({
                       type: NOTIFICATION_TYPES.ERROR,
-                      message: error.response ? error.response.data.error.code : 'Bulk Import of Research Somatic Variants Failed.',
+                      message: 'Bulk Import of Research Somatic Variants Failed.',
                       details: error.response ? error.response.data.error.message : error.message,
                       timeout: false,
                     });

--- a/ui/src/components/admin/Notifications/NotificationToaster.js
+++ b/ui/src/components/admin/Notifications/NotificationToaster.js
@@ -3,6 +3,9 @@ import Component from 'react-component-component';
 import { scroller } from 'react-scroll';
 import Spinner from 'react-spinkit';
 
+import { acknowledgeBulkImportStatus, stopAllImports } from 'components/admin/Model/actions/GenomicVariants';
+import useGenomicVariantImportNotifications from 'components/admin/Notifications/GenomicVariantImportNotifications';
+import useConfirmationModal from 'components/modals/ConfirmationModal';
 import { NotificationsContext } from './NotificationsController';
 import { NOTIFICATION_TYPES } from './../Notifications';
 
@@ -10,6 +13,7 @@ import CheckmarkIcon from 'icons/CheckmarkIcon';
 import CrossCircleIcon from 'icons/CrossCircleIcon';
 import ErrorTriangleIcon from 'icons/ErrorTriangleIcon';
 
+import { ButtonPill } from 'theme/adminControlsStyles';
 import {
   NotificationsToaster,
   Notification,
@@ -24,9 +28,20 @@ import {
   ShowHideButton,
   ShowHideButtonLabel,
   PlusMinusIcon,
+  ProgressBarContainer,
+  ProgressBarWrapper,
+  ProgressBarSectionComplete,
+  ProgressBarSectionFailed,
+  ProgressBarSectionIncomplete,
 } from 'theme/adminNotificationStyles';
-import { Col } from 'theme/system';
+import { Row, Col } from 'theme/system';
 import base from 'theme';
+
+import {
+  BULK_NONACTIONABLE_ERROR_ID,
+  VARIANT_IMPORT_STATUS,
+  VARIANT_IMPORT_TYPES,
+} from 'utils/constants';
 
 const {
   keyedPalette: { alizarinCrimson, pelorousapprox, trout, yellowOrange },
@@ -93,9 +108,139 @@ const renderIcon = type => {
   }
 };
 
+const BulkImportState = {
+  complete: 'COMPLETE',
+  stopped: 'STOPPED',
+  importing: 'IMPORTING',
+  off: 'OFF',
+};
+
 export default () => {
-  const { notifications, clearNotification } = useContext(NotificationsContext);
+  const { notifications, clearNotification, importProgress } = useContext(NotificationsContext);
+  const { updateImportNotifications, showUnexpectedImportError, hideErrorImportNotification } = useGenomicVariantImportNotifications();
   const [showMore, setShowMore] = useState(false);
+
+  const getBulkImports = () => {
+    if (!importProgress) {
+      return [];
+    }
+
+    return [
+      ...importProgress.queue,
+      ...importProgress.failed,
+      ...importProgress.stopped,
+      ...importProgress.success,
+    ].filter(x => x.importType === VARIANT_IMPORT_TYPES.bulk);
+  }
+
+  const isActiveBulkImport = () => !!getBulkImports().length;
+
+  const getProgressBannerType = () => {
+    if (!importProgress) {
+      return false;
+    }
+
+    return importProgress.running
+      ? NOTIFICATION_TYPES.LOADING
+      : NOTIFICATION_TYPES.SUCCESS;
+  };
+
+  const getImportState = () => {
+    if (!importProgress) {
+      return BulkImportState.off;
+    }
+
+    if (importProgress.running && getBulkImports().length) {
+      // Bulk import is currently running
+      return BulkImportState.importing;
+    } else if (importProgress.running && !getBulkImports().length) {
+      // Only individual imports running, no bulk
+      return BulkImportState.off;
+    } else if (getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.stopped).length) {
+      // Bulk import has been stopped
+      return BulkImportState.stopped;
+    } else {
+      // Bulk import is complete
+      return BulkImportState.complete;
+    }
+  };
+
+  const getProgressBannerMessage = () => {
+    let completeImports;
+    switch (getImportState()) {
+      case BulkImportState.complete:
+        completeImports = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.complete);
+        return `Import Complete: Research somatic variants for ${completeImports.length} model${completeImports.length === 1 ? ' has' : 's have'} successfully imported.`;
+      case BulkImportState.importing:
+        return `Importing: Research somatic variants for ${getBulkImports().length} model${getBulkImports().length === 1 ? ' is' : 's are'} currently importing.`;
+      case BulkImportState.stopped:
+        completeImports = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.complete);
+        return `Import Stopped: Research somatic variants for ${completeImports.length} model${completeImports.length === 1 ? ' has' : 's have'} successfully imported.`;
+      default:
+        // No visible banner for 'OFF'
+        return null;
+    }
+  };
+
+  const getProgressBannerDetails = () => {
+    switch (getImportState()) {
+      case BulkImportState.importing:
+        return 'You can continue to use the CMS, and will be notified of the status for each import.';
+      case BulkImportState.complete:
+      case BulkImportState.stopped:
+        return 'You can bulk publish the models below.';
+      default:
+        // No visible banner for 'OFF'
+        return null;
+    }
+  };
+
+  const renderProgressBar = () => {
+    const success = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.complete);
+    const failed = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.error);
+    const incomplete = getBulkImports().filter(x =>
+      x.status === VARIANT_IMPORT_STATUS.active
+      || x.status === VARIANT_IMPORT_STATUS.waiting
+      || x.status === VARIANT_IMPORT_STATUS.stopped
+    );
+
+    const meta = () => {
+      switch (getImportState()) {
+        case BulkImportState.importing:
+          return `In Progress: ${incomplete.length}`;
+        case BulkImportState.complete:
+          return `Import Complete`;
+        case BulkImportState.stopped:
+          return `Incomplete: ${incomplete.length}`;
+        default:
+          // No visible banner for 'OFF'
+          return null;
+      }
+    };
+
+    return (
+      <Row>
+        <Col>
+          <Row>
+            <ProgressBarContainer>
+              <ProgressBarWrapper>
+                <ProgressBarSectionComplete num={success.length} total={getBulkImports().length} />
+                <ProgressBarSectionFailed num={failed.length} total={getBulkImports().length} />
+                <ProgressBarSectionIncomplete num={incomplete.length} total={getBulkImports().length} />
+              </ProgressBarWrapper>
+            </ProgressBarContainer>
+          </Row>
+          <Row justifyContent={'space-between'}>
+            <span>Success: {success.length}</span>
+            <span>Failed: {failed.length}</span>
+          </Row>
+        </Col>
+        <Col>
+          <span style={{ marginLeft: '8px' }}>{meta()}</span>
+        </Col>
+      </Row>
+    );
+  };
 
   return (
     <Component
@@ -108,6 +253,68 @@ export default () => {
       }}
     >
       <NotificationsToaster name="notifications-toaster">
+        {isActiveBulkImport() && (
+          <Notification type={getProgressBannerType()}>
+            {renderIcon(getProgressBannerType())}
+            <Col>
+              <Message>{getProgressBannerMessage()}</Message>
+              <Details>{getProgressBannerDetails()}</Details>
+            </Col>
+            <Col style={{ padding: '0 12px' }}>
+              {renderProgressBar()}
+            </Col>
+            {getProgressBannerType() === NOTIFICATION_TYPES.LOADING && (
+              useConfirmationModal({
+                title: 'Stop Variant Import?',
+                message:
+                  'Are you sure you want to stop this variant import?',
+                confirmLabel: 'Yes, Stop',
+                onConfirm: async () => {
+                  stopAllImports().then(_ => {
+                    updateImportNotifications();
+                  }).catch(error => {
+                    showUnexpectedImportError(error);
+                  });
+                },
+              })(
+                <ButtonPill
+                  secondary
+                  style={{
+                    marginRight: 0,
+                    marginLeft: 'auto'
+                  }}
+                >
+                  Stop Import
+                </ButtonPill>,
+              )
+            )}
+            {getProgressBannerType() !== NOTIFICATION_TYPES.LOADING && (
+              <CrossCircleIcon
+                width={'17px'}
+                height={'17px'}
+                fill={trout}
+                style={closeIcon}
+                onClick={() => {
+                  acknowledgeBulkImportStatus(
+                    getBulkImports().map(x => x.modelName)
+                  ).then(data => {
+                    if (data.success) {
+                      // Remove error notifications for acknowledged errors
+                      (data.acknowledged || []).forEach(model => {
+                        hideErrorImportNotification(model.modelName);
+                      });
+                      // Remove bulk nonactionable error notification
+                      hideErrorImportNotification(BULK_NONACTIONABLE_ERROR_ID);
+                    }
+                    updateImportNotifications();
+                  }).catch(error => {
+                    showUnexpectedImportError(error);
+                  });
+                }}
+              />
+            )}
+          </Notification>
+        )}
         {notifications.slice(notifications.length > 5 && !showMore ? notifications.length - 5 : 0).reverse().map(notification => (
           <Notification key={notification.id} type={notification.type}>
             {renderIcon(notification.type)}

--- a/ui/src/components/admin/Notifications/NotificationToaster.js
+++ b/ui/src/components/admin/Notifications/NotificationToaster.js
@@ -37,6 +37,8 @@ const {
   keyedPalette: { alizarinCrimson, pelorousapprox, trout, yellowOrange },
 } = base;
 
+const NOTIFICATION_LIMIT = 5;
+
 const scrollIntoView = () =>
   scroller.scrollTo('notifications-toaster', {
     duration: 500,
@@ -131,7 +133,7 @@ export default () => {
         {isActiveBulkImport() && (
           <ProgressBanner renderIcon={renderIcon} />
         )}
-        {notifications.slice(notifications.length > 5 && !showMore ? notifications.length - 5 : 0).reverse().map(notification => (
+        {notifications.slice(notifications.length > NOTIFICATION_LIMIT && !showMore ? notifications.length - NOTIFICATION_LIMIT : 0).reverse().map(notification => (
           <Notification key={notification.id} type={notification.type}>
             {renderIcon(notification.type)}
             <Col width={'100%'}>
@@ -184,15 +186,15 @@ export default () => {
             )}
           </Notification>
         ))}
-        {notifications.length > 5 && (
+        {notifications.length > NOTIFICATION_LIMIT && (
           <ShowHideButton onClick={() => setShowMore(!showMore)}>
             <PlusMinusIcon showMore={showMore}>
               {showMore ? '-' : '+'}
             </PlusMinusIcon>
             <ShowHideButtonLabel>
-              {`${showMore ? 'Hide' : 'Show'} ${notifications.length - 5} ${
+              {`${showMore ? 'Hide' : 'Show'} ${notifications.length - NOTIFICATION_LIMIT} ${
                 showMore
-                  ? notifications.length - 5 === 1 ? 'notification' : 'notifications'
+                  ? notifications.length - NOTIFICATION_LIMIT === 1 ? 'notification' : 'notifications'
                   : 'more'
                 }`
               }

--- a/ui/src/components/admin/Notifications/NotificationToaster.js
+++ b/ui/src/components/admin/Notifications/NotificationToaster.js
@@ -3,17 +3,14 @@ import Component from 'react-component-component';
 import { scroller } from 'react-scroll';
 import Spinner from 'react-spinkit';
 
-import { acknowledgeBulkImportStatus, stopAllImports } from 'components/admin/Model/actions/GenomicVariants';
-import useGenomicVariantImportNotifications from 'components/admin/Notifications/GenomicVariantImportNotifications';
-import useConfirmationModal from 'components/modals/ConfirmationModal';
 import { NotificationsContext } from './NotificationsController';
-import { NOTIFICATION_TYPES } from './../Notifications';
+import NOTIFICATION_TYPES from './NotificationTypes';
+import ProgressBanner from './ProgressBanner';
 
 import CheckmarkIcon from 'icons/CheckmarkIcon';
 import CrossCircleIcon from 'icons/CrossCircleIcon';
 import ErrorTriangleIcon from 'icons/ErrorTriangleIcon';
 
-import { ButtonPill } from 'theme/adminControlsStyles';
 import {
   NotificationsToaster,
   Notification,
@@ -28,18 +25,11 @@ import {
   ShowHideButton,
   ShowHideButtonLabel,
   PlusMinusIcon,
-  ProgressBarContainer,
-  ProgressBarWrapper,
-  ProgressBarSectionComplete,
-  ProgressBarSectionFailed,
-  ProgressBarSectionIncomplete,
 } from 'theme/adminNotificationStyles';
-import { Row, Col } from 'theme/system';
+import { Col } from 'theme/system';
 import base from 'theme';
 
 import {
-  BULK_NONACTIONABLE_ERROR_ID,
-  VARIANT_IMPORT_STATUS,
   VARIANT_IMPORT_TYPES,
 } from 'utils/constants';
 
@@ -108,16 +98,8 @@ const renderIcon = type => {
   }
 };
 
-const BulkImportState = {
-  complete: 'COMPLETE',
-  stopped: 'STOPPED',
-  importing: 'IMPORTING',
-  off: 'OFF',
-};
-
 export default () => {
   const { notifications, clearNotification, importProgress } = useContext(NotificationsContext);
-  const { updateImportNotifications, showUnexpectedImportError, hideErrorImportNotification } = useGenomicVariantImportNotifications();
   const [showMore, setShowMore] = useState(false);
 
   const getBulkImports = () => {
@@ -135,113 +117,6 @@ export default () => {
 
   const isActiveBulkImport = () => !!getBulkImports().length;
 
-  const getProgressBannerType = () => {
-    if (!importProgress) {
-      return false;
-    }
-
-    return importProgress.running
-      ? NOTIFICATION_TYPES.LOADING
-      : NOTIFICATION_TYPES.SUCCESS;
-  };
-
-  const getImportState = () => {
-    if (!importProgress) {
-      return BulkImportState.off;
-    }
-
-    if (importProgress.running && getBulkImports().length) {
-      // Bulk import is currently running
-      return BulkImportState.importing;
-    } else if (importProgress.running && !getBulkImports().length) {
-      // Only individual imports running, no bulk
-      return BulkImportState.off;
-    } else if (getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.stopped).length) {
-      // Bulk import has been stopped
-      return BulkImportState.stopped;
-    } else {
-      // Bulk import is complete
-      return BulkImportState.complete;
-    }
-  };
-
-  const getProgressBannerMessage = () => {
-    let completeImports;
-    switch (getImportState()) {
-      case BulkImportState.complete:
-        completeImports = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.complete);
-        return `Import Complete: Research somatic variants for ${completeImports.length} model${completeImports.length === 1 ? ' has' : 's have'} successfully imported.`;
-      case BulkImportState.importing:
-        return `Importing: Research somatic variants for ${getBulkImports().length} model${getBulkImports().length === 1 ? ' is' : 's are'} currently importing.`;
-      case BulkImportState.stopped:
-        completeImports = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.complete);
-        return `Import Stopped: Research somatic variants for ${completeImports.length} model${completeImports.length === 1 ? ' has' : 's have'} successfully imported.`;
-      default:
-        // No visible banner for 'OFF'
-        return null;
-    }
-  };
-
-  const getProgressBannerDetails = () => {
-    switch (getImportState()) {
-      case BulkImportState.importing:
-        return 'You can continue to use the CMS, and will be notified of the status for each import.';
-      case BulkImportState.complete:
-      case BulkImportState.stopped:
-        return 'You can bulk publish the models below.';
-      default:
-        // No visible banner for 'OFF'
-        return null;
-    }
-  };
-
-  const renderProgressBar = () => {
-    const success = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.complete);
-    const failed = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.error);
-    const incomplete = getBulkImports().filter(x =>
-      x.status === VARIANT_IMPORT_STATUS.active
-      || x.status === VARIANT_IMPORT_STATUS.waiting
-      || x.status === VARIANT_IMPORT_STATUS.stopped
-    );
-
-    const meta = () => {
-      switch (getImportState()) {
-        case BulkImportState.importing:
-          return `In Progress: ${incomplete.length}`;
-        case BulkImportState.complete:
-          return `Import Complete`;
-        case BulkImportState.stopped:
-          return `Incomplete: ${incomplete.length}`;
-        default:
-          // No visible banner for 'OFF'
-          return null;
-      }
-    };
-
-    return (
-      <Row>
-        <Col>
-          <Row>
-            <ProgressBarContainer>
-              <ProgressBarWrapper>
-                <ProgressBarSectionComplete num={success.length} total={getBulkImports().length} />
-                <ProgressBarSectionFailed num={failed.length} total={getBulkImports().length} />
-                <ProgressBarSectionIncomplete num={incomplete.length} total={getBulkImports().length} />
-              </ProgressBarWrapper>
-            </ProgressBarContainer>
-          </Row>
-          <Row justifyContent={'space-between'}>
-            <span>Success: {success.length}</span>
-            <span>Failed: {failed.length}</span>
-          </Row>
-        </Col>
-        <Col>
-          <span style={{ marginLeft: '8px' }}>{meta()}</span>
-        </Col>
-      </Row>
-    );
-  };
-
   return (
     <Component
       notifications={notifications}
@@ -254,66 +129,7 @@ export default () => {
     >
       <NotificationsToaster name="notifications-toaster">
         {isActiveBulkImport() && (
-          <Notification type={getProgressBannerType()}>
-            {renderIcon(getProgressBannerType())}
-            <Col>
-              <Message>{getProgressBannerMessage()}</Message>
-              <Details>{getProgressBannerDetails()}</Details>
-            </Col>
-            <Col style={{ padding: '0 12px' }}>
-              {renderProgressBar()}
-            </Col>
-            {getProgressBannerType() === NOTIFICATION_TYPES.LOADING && (
-              useConfirmationModal({
-                title: 'Stop Variant Import?',
-                message:
-                  'Are you sure you want to stop this variant import?',
-                confirmLabel: 'Yes, Stop',
-                onConfirm: async () => {
-                  stopAllImports().then(_ => {
-                    updateImportNotifications();
-                  }).catch(error => {
-                    showUnexpectedImportError(error);
-                  });
-                },
-              })(
-                <ButtonPill
-                  secondary
-                  style={{
-                    marginRight: 0,
-                    marginLeft: 'auto'
-                  }}
-                >
-                  Stop Import
-                </ButtonPill>,
-              )
-            )}
-            {getProgressBannerType() !== NOTIFICATION_TYPES.LOADING && (
-              <CrossCircleIcon
-                width={'17px'}
-                height={'17px'}
-                fill={trout}
-                style={closeIcon}
-                onClick={() => {
-                  acknowledgeBulkImportStatus(
-                    getBulkImports().map(x => x.modelName)
-                  ).then(data => {
-                    if (data.success) {
-                      // Remove error notifications for acknowledged errors
-                      (data.acknowledged || []).forEach(model => {
-                        hideErrorImportNotification(model.modelName);
-                      });
-                      // Remove bulk nonactionable error notification
-                      hideErrorImportNotification(BULK_NONACTIONABLE_ERROR_ID);
-                    }
-                    updateImportNotifications();
-                  }).catch(error => {
-                    showUnexpectedImportError(error);
-                  });
-                }}
-              />
-            )}
-          </Notification>
+          <ProgressBanner renderIcon={renderIcon} />
         )}
         {notifications.slice(notifications.length > 5 && !showMore ? notifications.length - 5 : 0).reverse().map(notification => (
           <Notification key={notification.id} type={notification.type}>

--- a/ui/src/components/admin/Notifications/ProgressBanner.js
+++ b/ui/src/components/admin/Notifications/ProgressBanner.js
@@ -1,0 +1,241 @@
+import React, { useContext } from 'react';
+
+import { acknowledgeBulkImportStatus, stopAllImports } from 'components/admin/Model/actions/GenomicVariants';
+import useGenomicVariantImportNotifications from 'components/admin/Notifications/GenomicVariantImportNotifications';
+import useConfirmationModal from 'components/modals/ConfirmationModal';
+import { NotificationsContext } from './NotificationsController';
+import NOTIFICATION_TYPES from './NotificationTypes';
+
+import CheckmarkIcon from 'icons/CheckmarkIcon';
+import CrossCircleIcon from 'icons/CrossCircleIcon';
+import CrossIcon from 'icons/CrossIcon';
+
+import { ButtonPill } from 'theme/adminControlsStyles';
+import {
+  Notification,
+  Message,
+  Details,
+  closeIcon,
+  ProgressBarContainer,
+  ProgressBarWrapper,
+  ProgressBarSectionComplete,
+  ProgressBarSectionFailed,
+  ProgressBarSectionIncomplete,
+  ProgressBarLabel,
+} from 'theme/adminNotificationStyles';
+import { Row, Col } from 'theme/system';
+import base from 'theme';
+
+import {
+  BULK_NONACTIONABLE_ERROR_ID,
+  VARIANT_IMPORT_STATUS,
+  VARIANT_IMPORT_TYPES,
+} from 'utils/constants';
+
+const {
+  keyedPalette: { trout },
+} = base;
+
+
+const BulkImportState = {
+  complete: 'COMPLETE',
+  stopped: 'STOPPED',
+  importing: 'IMPORTING',
+  off: 'OFF',
+};
+
+const ProgressBanner = ({ renderIcon }) => {
+  const { importProgress } = useContext(NotificationsContext);
+  const { updateImportNotifications, showUnexpectedImportError, hideErrorImportNotification } = useGenomicVariantImportNotifications();
+
+  const getBulkImports = () => {
+    if (!importProgress) {
+      return [];
+    }
+
+    return [
+      ...importProgress.queue,
+      ...importProgress.failed,
+      ...importProgress.stopped,
+      ...importProgress.success,
+    ].filter(x => x.importType === VARIANT_IMPORT_TYPES.bulk);
+  }
+
+  const getProgressBannerType = () => {
+    if (!importProgress) {
+      return false;
+    }
+
+    return importProgress.running
+      ? NOTIFICATION_TYPES.LOADING
+      : NOTIFICATION_TYPES.SUCCESS;
+  };
+
+  const getProgressBannerDetails = () => {
+    switch (getImportState()) {
+      case BulkImportState.importing:
+        return 'You can continue to use the CMS, and will be notified of the status for each import.';
+      case BulkImportState.complete:
+      case BulkImportState.stopped:
+        return 'You can bulk publish the models below.';
+      default:
+        // No visible banner for 'OFF'
+        return null;
+    }
+  };
+
+  const getImportState = () => {
+    if (!importProgress) {
+      return BulkImportState.off;
+    }
+
+    if (importProgress.running && getBulkImports().length) {
+      // Bulk import is currently running
+      return BulkImportState.importing;
+    } else if (importProgress.running && !getBulkImports().length) {
+      // Only individual imports running, no bulk
+      return BulkImportState.off;
+    } else if (getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.stopped).length) {
+      // Bulk import has been stopped
+      return BulkImportState.stopped;
+    } else {
+      // Bulk import is complete
+      return BulkImportState.complete;
+    }
+  };
+
+  const getProgressBannerMessage = () => {
+    let completeImports;
+    switch (getImportState()) {
+      case BulkImportState.complete:
+        completeImports = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.complete);
+        return `Import Complete: Research somatic variants for ${completeImports.length} model${completeImports.length === 1 ? ' has' : 's have'} successfully imported.`;
+      case BulkImportState.importing:
+        return `Importing: Research somatic variants for ${getBulkImports().length} model${getBulkImports().length === 1 ? ' is' : 's are'} currently importing.`;
+      case BulkImportState.stopped:
+        completeImports = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.complete);
+        return `Import Stopped: Research somatic variants for ${completeImports.length} model${completeImports.length === 1 ? ' has' : 's have'} successfully imported.`;
+      default:
+        // No visible banner for 'OFF'
+        return null;
+    }
+  };
+
+  const renderProgressBar = () => {
+    const success = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.complete);
+    const failed = getBulkImports().filter(x => x.status === VARIANT_IMPORT_STATUS.error);
+    const incomplete = getBulkImports().filter(x =>
+      x.status === VARIANT_IMPORT_STATUS.active
+      || x.status === VARIANT_IMPORT_STATUS.waiting
+      || x.status === VARIANT_IMPORT_STATUS.stopped
+    );
+
+    const meta = () => {
+      switch (getImportState()) {
+        case BulkImportState.importing:
+          return `In Progress: ${incomplete.length}`;
+        case BulkImportState.complete:
+          return `Import Complete`;
+        case BulkImportState.stopped:
+          return `Incomplete: ${incomplete.length}`;
+        default:
+          // No visible banner for 'OFF'
+          return null;
+      }
+    };
+
+    return (
+      <Row>
+        <Col>
+          <Row>
+            <ProgressBarContainer>
+              <ProgressBarWrapper>
+                <ProgressBarSectionComplete num={success.length} total={getBulkImports().length} />
+                <ProgressBarSectionFailed num={failed.length} total={getBulkImports().length} />
+                <ProgressBarSectionIncomplete num={incomplete.length} total={getBulkImports().length} />
+              </ProgressBarWrapper>
+            </ProgressBarContainer>
+          </Row>
+          <Row justifyContent={'space-between'}>
+            <ProgressBarLabel>
+              <CheckmarkIcon fill={'#3AB'} width={'10px'} height={'10px'} />
+              Success: {success.length}
+            </ProgressBarLabel>
+            <ProgressBarLabel>
+              <CrossIcon width={'8px'} height={'8px'} />
+              Failed: {failed.length}
+            </ProgressBarLabel>
+          </Row>
+        </Col>
+        <Col>
+          <span style={{ marginLeft: '8px' }}>{meta()}</span>
+        </Col>
+      </Row>
+    );
+  };
+
+  return (
+    <Notification type={getProgressBannerType()}>
+      {renderIcon(getProgressBannerType())}
+      <Col>
+        <Message>{getProgressBannerMessage()}</Message>
+        <Details>{getProgressBannerDetails()}</Details>
+      </Col>
+      <Col style={{ padding: '0 12px' }}>
+        {renderProgressBar()}
+      </Col>
+      {getProgressBannerType() === NOTIFICATION_TYPES.LOADING && (
+        useConfirmationModal({
+          title: 'Stop Variant Import?',
+          message:
+            'Are you sure you want to stop this variant import?',
+          confirmLabel: 'Yes, Stop',
+          onConfirm: async () => {
+            stopAllImports().then(_ => {
+              updateImportNotifications();
+            }).catch(error => {
+              showUnexpectedImportError(error);
+            });
+          },
+        })(
+          <ButtonPill
+            secondary
+            style={{
+              marginRight: 0,
+              marginLeft: 'auto'
+            }}
+          >
+            Stop Import
+          </ButtonPill>,
+        )
+      )}
+      {getProgressBannerType() !== NOTIFICATION_TYPES.LOADING && (
+        <CrossCircleIcon
+          width={'17px'}
+          height={'17px'}
+          fill={trout}
+          style={closeIcon}
+          onClick={() => {
+            acknowledgeBulkImportStatus(
+              getBulkImports().map(x => x.modelName)
+            ).then(data => {
+              if (data.success) {
+                // Remove error notifications for acknowledged errors
+                (data.acknowledged || []).forEach(model => {
+                  hideErrorImportNotification(model.modelName);
+                });
+                // Remove bulk nonactionable error notification
+                hideErrorImportNotification(BULK_NONACTIONABLE_ERROR_ID);
+              }
+              updateImportNotifications();
+            }).catch(error => {
+              showUnexpectedImportError(error);
+            });
+          }}
+        />
+      )}
+    </Notification>
+  );
+};
+
+export default ProgressBanner;

--- a/ui/src/theme/adminNotificationStyles.js
+++ b/ui/src/theme/adminNotificationStyles.js
@@ -244,3 +244,8 @@ export const ProgressBarSectionIncomplete = styled('span')`
   background: ${ironApprox};
   ${({ num, total }) => `width: calc(${num}/${total} * 100%);`}
 `;
+
+export const ProgressBarLabel = styled('span')`
+  display: flex;
+  align-items: center;
+`;

--- a/ui/src/theme/adminNotificationStyles.js
+++ b/ui/src/theme/adminNotificationStyles.js
@@ -10,7 +10,20 @@ import { Col, Row } from 'theme/system';
 
 const {
   fonts: { openSans },
-  keyedPalette: { aquaSpring, black, bombay, cinderella, cinnabar, mauvelous, morningGlory, stiletto, white, yellowOrange },
+  keyedPalette: {
+    aquaSpring,
+    black,
+    bombay,
+    cinderella,
+    cinnabar,
+    elm,
+    ironApprox,
+    mauvelous,
+    morningGlory,
+    stiletto,
+    white,
+    yellowOrange,
+  },
   transparency: { yellowOrange20 },
 } = base;
 
@@ -194,4 +207,40 @@ export const PlusMinusIcon = styled('span')`
   font-size: 10px;
   margin-right: 4px;
   ${({ showMore }) => showMore && 'padding-bottom: 2px;'}
+`;
+
+export const ProgressBarContainer = styled('div')`
+  display: block;
+  width: 290px;
+  height: 14px;
+  border-radius: 10px;
+  border: solid 1px ${bombay};
+  overflow: hidden;
+  position: relative;
+  margin-top: 4px;
+`;
+
+export const ProgressBarWrapper = styled('div')`
+  display: flex;
+`;
+
+export const ProgressBarSectionComplete = styled('span')`
+  display: inline-block;
+  height: 12px;
+  background: ${elm};
+  ${({ num, total }) => `width: calc(${num}/${total} * 100%);`}
+`;
+
+export const ProgressBarSectionFailed = styled('span')`
+  display: inline-block;
+  height: 12px;
+  background: ${cinnabar};
+  ${({ num, total }) => `width: calc(${num}/${total} * 100%);`}
+`;
+
+export const ProgressBarSectionIncomplete = styled('span')`
+  display: inline-block;
+  height: 12px;
+  background: ${ironApprox};
+  ${({ num, total }) => `width: calc(${num}/${total} * 100%);`}
 `;

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -1,3 +1,5 @@
+const BULK_NONACTIONABLE_ERROR_ID = 'BULK_NONACTIONABLE_IMPORT_ERRORS';
+
 const BULK_UPLOAD_TYPES = {
   MODEL: 'model',
   VARIANT: 'variant',
@@ -34,6 +36,11 @@ const GENOMIC_VARIANTS_IMPORT_ERRORS = {
 
 const imgPath = '/api/data/images';
 
+const VARIANT_IMPORT_TYPES = {
+  bulk: 'BULK',
+  individual: 'INDIVIDUAL',
+};
+
 const VARIANT_TYPES = {
   clinical: 'clinical',
   histopathological: 'histopathological biomarker',
@@ -45,6 +52,7 @@ const VARIANT_IMPORT_STATUS = {
   complete: 'COMPLETE',
   error: 'ERROR',
   stopped: 'STOPPED',
+  waiting: 'WAITING',
 };
 
 const VARIANT_OVERWRITE_OPTIONS = {
@@ -54,6 +62,7 @@ const VARIANT_OVERWRITE_OPTIONS = {
 };
 
 export {
+  BULK_NONACTIONABLE_ERROR_ID,
   BULK_UPLOAD_DISPLAY_TYPES,
   BULK_UPLOAD_TYPES,
   GDC_CASE_URL_BASE,
@@ -62,6 +71,7 @@ export {
   GDC_MODEL_STATES,
   GENOMIC_VARIANTS_IMPORT_ERRORS,
   imgPath,
+  VARIANT_IMPORT_TYPES,
   VARIANT_IMPORT_STATUS,
   VARIANT_OVERWRITE_OPTIONS,
   VARIANT_TYPES,


### PR DESCRIPTION
Adds the very long-awaited bulk import progress banner notification, and the slightly less long-awaited stop import button. Also includes some bug fixes and code cleanups.

**The polling interval has been reduced from 1s to 0.5s. In local testing this hasn't caused any issues, and allows the Progress Bar to show more granular import steps. If you think this can cause an issue, let me know and I'll revert it.**

### Key Change
---
* `ui/src/components/admin/Notifications/ProgressBanner.js` has been created as a new notification which appears above the list of the regular rendered notifications in `NotificationToaster.js`

### Commits
---
**⚡️ Reduce polling interval for import status check**
* Decrease the time between intervals to show a more accurate representation of import progress

**🐛 Fix bug in import acknowledgement and stopping**
* Addresses an issue where stopped imports could cause the import lists to store invalid objects

**✨ Add Import Progress Banner and Stop Import Button (#849 #856)**
* Adds a new Import Progress banner notification for bulk variant imports
* Import Progress banner contains a button to allow the content manager to stop in-progress imports
* Also includes some refactoring of import notifications and unexpected error handling

**♻️ Refactor ProgressBanner out of Notifications (#849)**
* Move all progress bar-related code into its own component
* Add the checkmark and cross icons to the progress banner

**♻️ Refactor Notification Limit Into a Constant**