### PR TITLE
🐛 Prevent variant import from running when all bulk model uploads fail (#892)

### DIFF
--- a/ui/src/components/admin/ModelsManager/ModelManagerController.js
+++ b/ui/src/components/admin/ModelsManager/ModelManagerController.js
@@ -211,6 +211,10 @@ export default ({ baseUrl, cmsBase, children, ...props }) => (
                       switch (overwriteVariants) {
                         case VARIANT_OVERWRITE_OPTIONS.allModels:
                           modelNames = [...result.new, ...result.updated, ...result.unchanged];
+                          if (!modelNames.length) {
+                            return;
+                          }
+
                           await importBulkGenomicVariants(modelNames)
                             .then(response => {
                               if (response.data.success) {
@@ -231,6 +235,10 @@ export default ({ baseUrl, cmsBase, children, ...props }) => (
                           break;
                         case VARIANT_OVERWRITE_OPTIONS.cleanOnly:
                           modelNames = [...result.new, ...result.updated, ...result.unchanged];
+                          if (!modelNames.length) {
+                            return;
+                          }
+
                           const checkVariantsResponse = await auditGenomicVariantsSpecificModels(modelNames);
                           await importBulkGenomicVariants(checkVariantsResponse.data.clean)
                             .then(response => {


### PR DESCRIPTION
* Fixes a bug where a call to import variants for an empty model list would be made