### PR TITLE
🐛 More bugfixes for Bulk Variant Import UI (#890 #894 #893)

### DIFF
--- a/cms/src/services/gdc-importer/VariantImporter.js
+++ b/cms/src/services/gdc-importer/VariantImporter.js
@@ -211,8 +211,9 @@ const VariantImporter = (function() {
       };
     }
 
-    // Make sure we don't have duplicate imports queued up
+    // Remove duplicate imports
     stopImport(modelName);
+    acknowledge(modelName);
 
     try {
       let newImport;
@@ -314,7 +315,9 @@ const VariantImporter = (function() {
       };
     }
 
-    cleanLists();
+    // Remove duplicate imports
+    stopBulkImport(models);
+    acknowledgeBulk(models);
 
     // Filter out models that don't exist within HCMI db
     let noMatchingModel = [];
@@ -449,10 +452,21 @@ const VariantImporter = (function() {
     return targets.map(target => target.getData());
   };
 
-  const stopBulkImport = async () => {
+  const stopBulkImport = async (modelNames = []) => {
     pause();
 
-    const targets = queue;
+    let targets = [];
+    if (modelNames.length) {
+      modelNames.forEach(modelName => {
+        targets = [
+          ...targets,
+          ...queue.filter(i => i && i.modelName === modelName),
+        ];
+      });
+    } else {
+      targets = queue;
+    }
+
     if (targets.length) {
       targets.forEach(target => target.stop());
       stopped = [...stopped, ...targets];

--- a/ui/src/components/admin/AdminView.js
+++ b/ui/src/components/admin/AdminView.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { Route } from 'react-router-dom';
 
-import { checkImportStatus } from 'components/admin/Model/actions/GenomicVariants';
 import { useGenomicVariantImportNotifications } from 'components/admin/Notifications';
 
 import AdminNav from './AdminNav';
@@ -20,37 +19,20 @@ export default ({ location }) => {
   const {
     importNotifications,
     importRunning,
-    updateNotificationsFromStatus,
-    showUnexpectedImportError,
+    fetchImportStatus,
   } = useGenomicVariantImportNotifications();
 
   // Check for active genomic variant imports on page load
   useEffect(() => {
-    const getActiveImports = async () => {
-      await checkImportStatus()
-        .then(importStatus => {
-          updateNotificationsFromStatus(importStatus);
-        }).catch(error => {
-          showUnexpectedImportError(error);
-        });
-    };
-
     if (!didMountRef || !didMountRef.current) {
-      getActiveImports();
+      fetchImportStatus();
       didMountRef.current = true;
     }
   }, []);
 
   // Poll for status changes on any active imports
   useInterval(
-    () => {
-      checkImportStatus()
-        .then(importStatus => {
-          updateNotificationsFromStatus(importStatus);
-        }).catch(error => {
-          showUnexpectedImportError(error);
-        });
-    },
+    async () => await fetchImportStatus(),
     importRunning || !isEmpty(importNotifications) ? 500 : null,
   );
 

--- a/ui/src/components/admin/Notifications/GenomicVariantImportNotifications.js
+++ b/ui/src/components/admin/Notifications/GenomicVariantImportNotifications.js
@@ -13,7 +13,6 @@ import withConfirmMafFileModal from 'components/modals/ConfirmMafFileModal';
 import NOTIFICATION_TYPES from './NotificationTypes';
 import {
   BULK_NONACTIONABLE_ERROR_ID,
-  // DEFAULT_NONACTIONABLE_IMPORTS,
   GDC_MODEL_STATES,
   GENOMIC_VARIANTS_IMPORT_ERRORS,
   VARIANT_IMPORT_TYPES
@@ -384,10 +383,6 @@ const useGenomicVariantImportNotifications = () => {
     hideErrorImportNotification(BULK_NONACTIONABLE_ERROR_ID);
   };
 
-  // const resetBulkNonActionableImportErrors = () => {
-  //   setNonactionableImports(DEFAULT_NONACTIONABLE_IMPORTS);
-  // };
-
   const getNonActionableImportErrorModels = () => {
     return [...nonactionableImports[GDC_MODEL_STATES.modelNotFound], ...nonactionableImports[GDC_MODEL_STATES.noMafs]];
   };
@@ -506,7 +501,6 @@ const useGenomicVariantImportNotifications = () => {
     updateNotificationsFromStatus,
     fetchImportStatus,
     hideErrorImportNotification,
-    // resetBulkNonActionableImportErrors,
     importRunning: importProgress.running,
     showBulkNonActionableImportErrors,
     hideBulkNonActionableImportErrors,

--- a/ui/src/components/admin/Notifications/GenomicVariantImportNotifications.js
+++ b/ui/src/components/admin/Notifications/GenomicVariantImportNotifications.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { NotificationsContext } from './NotificationsController';
 
@@ -7,11 +7,13 @@ import {
   acknowledgeBulkImportStatus,
   checkImportStatus,
 } from 'components/admin/Model/actions/GenomicVariants';
+import { isEqual } from 'components/admin/helpers/notifications';
 import withConfirmMafFileModal from 'components/modals/ConfirmMafFileModal';
 
 import NOTIFICATION_TYPES from './NotificationTypes';
 import {
   BULK_NONACTIONABLE_ERROR_ID,
+  // DEFAULT_NONACTIONABLE_IMPORTS,
   GDC_MODEL_STATES,
   GENOMIC_VARIANTS_IMPORT_ERRORS,
   VARIANT_IMPORT_TYPES
@@ -60,7 +62,23 @@ const ConfirmMafFileError = ({ modelName, tissueStatus, files, error, onConfirm 
   );
 };
 
-const BulkNonActionableImportErrors = ({ modelNotFound = [], noMafs = [] }) => {
+const BulkNonActionableImportErrors = () => {
+  const { nonactionableImports } = useContext(NotificationsContext);
+  const [modelNotFound, setModelNotFound] = useState([]);
+  const [noMafs, setNoMafs] = useState([]);
+
+  useEffect(() => {
+    if (nonactionableImports) {
+      if (!isEqual(nonactionableImports[GDC_MODEL_STATES.modelNotFound], modelNotFound)) {
+        setModelNotFound(nonactionableImports[GDC_MODEL_STATES.modelNotFound]);
+      }
+
+      if (!isEqual(nonactionableImports[GDC_MODEL_STATES.noMafs], noMafs)) {
+        setNoMafs(nonactionableImports[GDC_MODEL_STATES.modelNotFound]);
+      }
+    }
+  }, [nonactionableImports, modelNotFound, noMafs]);
+
   return (
     <>
       <NotificationTableHeaderRow>
@@ -86,7 +104,6 @@ const BulkNonActionableImportErrors = ({ modelNotFound = [], noMafs = [] }) => {
 const useGenomicVariantImportNotifications = () => {
   const {
     notifications,
-    setNotifications,
     appendNotification,
     clearNotification,
     importNotifications,
@@ -188,6 +205,11 @@ const useGenomicVariantImportNotifications = () => {
               error={GDC_MODEL_STATES.singleNgcmPlusEngcm}
               files={error.files}
               tissueStatus={error.tissueStatus}
+              onConfirm={
+                error.importType === VARIANT_IMPORT_TYPES.individual
+                  ? () => addImportNotification(modelName)
+                  : undefined
+              }
             />
           ),
           timeout: false,
@@ -205,6 +227,11 @@ const useGenomicVariantImportNotifications = () => {
               error={GDC_MODEL_STATES.noNgcm}
               files={error.files}
               tissueStatus={error.tissueStatus}
+              onConfirm={
+                error.importType === VARIANT_IMPORT_TYPES.individual
+                  ? () => addImportNotification(modelName)
+                  : undefined
+              }
             />
           ),
           timeout: false,
@@ -222,6 +249,11 @@ const useGenomicVariantImportNotifications = () => {
               error={GDC_MODEL_STATES.multipleNgcm}
               files={error.files}
               tissueStatus={error.tissueStatus}
+              onConfirm={
+                error.importType === VARIANT_IMPORT_TYPES.individual
+                  ? () => addImportNotification(modelName)
+                  : undefined
+              }
             />
           ),
           timeout: false,
@@ -300,7 +332,6 @@ const useGenomicVariantImportNotifications = () => {
     const existingNotification = notifications.find(x => x.modelName === modelName);
 
     if (existingNotification) {
-      existingNotification.onClose = null;
       existingNotification.clear();
     }
   };
@@ -314,57 +345,65 @@ const useGenomicVariantImportNotifications = () => {
     });
   };
 
-  const showBulkNonActionableImportErrors = (modelNotFound, noMafs) => {
+  const showBulkNonActionableImportErrors = () => {
     const modelName = BULK_NONACTIONABLE_ERROR_ID;
 
-    if (!modelNotFound.length && !noMafs.length) {
+    // Hide if there are no bulk nonactionable errors
+    if (!getNonActionableImportErrorModels().length) {
+      hideBulkNonActionableImportErrors();
       return;
     }
 
+    // Remove existing notification before adding new values, brings it back to the top of the list
     if (notifications.find(x => x.modelName === modelName)) {
-      updateBulkNonActionableImportErrors(modelNotFound, noMafs);
-      return;
+      hideBulkNonActionableImportErrors();
     }
 
     appendNotification({
       type: NOTIFICATION_TYPES.ERROR,
       message: 'Import Errors with No Action Required.',
-      details: <BulkNonActionableImportErrors modelNotFound={modelNotFound} noMafs={noMafs} />,
+      details: <BulkNonActionableImportErrors />,
       timeout: false,
       modelName: modelName,
-      onClose: () => { acknowledgeBulkAndUpdateNotifications([...modelNotFound, ...noMafs]) },
+      onClose: () => {
+        // Can't access the latest state normally since the callback is bound when the notification is created
+        // Use 'setState' without updating the state to access the latest value within a bound callback
+        // Via: https://stackoverflow.com/q/57847594
+        setNonactionableImports(currentNonActionableImports => {
+          acknowledgeBulkAndUpdateNotifications([
+            ...currentNonActionableImports[GDC_MODEL_STATES.modelNotFound],
+            ...currentNonActionableImports[GDC_MODEL_STATES.noMafs],
+          ]);
+          return currentNonActionableImports;
+        });
+      },
     });
   };
 
-  const updateBulkNonActionableImportErrors = (modelNotFound, noMafs) => {
-    const modelName = BULK_NONACTIONABLE_ERROR_ID;
-    const existingNotification = notifications.find(x => x.modelName === modelName);
-
-    if (!existingNotification) {
-      showBulkNonActionableImportErrors(modelNotFound, noMafs);
-      return;
-    }
-
-    const index = notifications.findIndex(x => x.modelName === modelName);
-
-    existingNotification.details = <BulkNonActionableImportErrors modelNotFound={modelNotFound} noMafs={noMafs} />;
-    existingNotification.onClose = () => { acknowledgeBulkAndUpdateNotifications([...modelNotFound, ...noMafs]) };
-
-    setNotifications(notifications => [...notifications.slice(0, index), existingNotification, ...notifications.slice(index + 1)]);
+  const hideBulkNonActionableImportErrors = () => {
+    hideErrorImportNotification(BULK_NONACTIONABLE_ERROR_ID);
   };
 
-  const updateNotificationsFromStatus = importStatus => {
-    setImportProgress(importStatus);
+  // const resetBulkNonActionableImportErrors = () => {
+  //   setNonactionableImports(DEFAULT_NONACTIONABLE_IMPORTS);
+  // };
+
+  const getNonActionableImportErrorModels = () => {
+    return [...nonactionableImports[GDC_MODEL_STATES.modelNotFound], ...nonactionableImports[GDC_MODEL_STATES.noMafs]];
+  };
+
+  const updateNotificationsFromStatus = async () => {
+    const { queue, stopped, success, failed } = importProgress;
 
     // Add import notifications for individual imports in the queue
-    const individualQueuedImports = importStatus.queue.filter(x => x.importType === VARIANT_IMPORT_TYPES.individual);
+    const individualQueuedImports = (queue || []).filter(x => x.importType === VARIANT_IMPORT_TYPES.individual);
     individualQueuedImports.forEach(importItem => {
       const modelName = importItem.modelName;
       addImportNotification(modelName);
     });
 
     // Remove import notification and show stopped notification for stopped individual imports
-    const individualStoppedImports = importStatus.stopped.filter(x => x.importType === VARIANT_IMPORT_TYPES.individual);
+    const individualStoppedImports = (stopped || []).filter(x => x.importType === VARIANT_IMPORT_TYPES.individual);
     individualStoppedImports.forEach(stoppedImport => {
       const modelName = stoppedImport.modelName;
       removeImportNotification(modelName);
@@ -372,15 +411,29 @@ const useGenomicVariantImportNotifications = () => {
     });
 
     // Remove import notification and show success notification for completed individual imports
-    const individualCompletedImports = importStatus.success.filter(x => x.importType === VARIANT_IMPORT_TYPES.individual);
+    const individualCompletedImports = (success || []).filter(x => x.importType === VARIANT_IMPORT_TYPES.individual);
     individualCompletedImports.forEach(completedImport => {
       const modelName = completedImport.modelName;
       removeImportNotification(modelName);
       showSuccessfulImportNotification(modelName);
     });
 
+    // Remove import errors for re-queued bulk imports (resolved errors)
+    const bulkQueuedImports = (queue || []).filter(x => x.importType === VARIANT_IMPORT_TYPES.bulk);
+    bulkQueuedImports.forEach(queuedImport => {
+      const modelName = queuedImport.modelName;
+      hideErrorImportNotification(modelName);
+    })
+
+    // Remove import errors for completed bulk imports
+    const bulkCompletedImports = (success || []).filter(x => x.importType === VARIANT_IMPORT_TYPES.bulk);
+    bulkCompletedImports.forEach(completedImport => {
+      const modelName = completedImport.modelName;
+      hideErrorImportNotification(modelName);
+    })
+
     // Add import error notifications for failed imports
-    const failedImports = importStatus.failed;
+    const failedImports = failed || [];
     const bulkModelNotFound = [...nonactionableImports[GDC_MODEL_STATES.modelNotFound]];
     const bulkNoMafs = [...nonactionableImports[GDC_MODEL_STATES.noMafs]];
     let newBulkModelNotFound = [];
@@ -395,7 +448,7 @@ const useGenomicVariantImportNotifications = () => {
 
       if (failedImport.actionable || failedImport.importType === VARIANT_IMPORT_TYPES.individual) {
         // Actionable errors and errors for individual imports get shown normally
-        showErrorImportNotification(modelName, failedImport);
+       showErrorImportNotification(modelName, failedImport);
       } else {
         // Non-actionable errors for bulk imports get grouped together
         switch (failedImport.error.code) {
@@ -412,20 +465,15 @@ const useGenomicVariantImportNotifications = () => {
     });
 
     // Update non-actionable import errors if the models have changed
-    if (bulkModelNotFound.length !== newBulkModelNotFound.length || bulkNoMafs.length !== newBulkNoMafs.length) {
+    if (!isEqual(bulkModelNotFound, newBulkModelNotFound) || !isEqual(bulkNoMafs, newBulkNoMafs)) {
       setNonactionableImports({
         [GDC_MODEL_STATES.modelNotFound]: newBulkModelNotFound,
         [GDC_MODEL_STATES.noMafs]: newBulkNoMafs,
       });
-
-      // Only show the bulk non-actionable import error if there are models in the list
-      if (newBulkModelNotFound.length || newBulkNoMafs.length) {
-        showBulkNonActionableImportErrors(newBulkModelNotFound, newBulkNoMafs);
-      }
     }
   };
 
-  const updateImportNotifications = async () => {
+  const fetchImportStatus = async () => {
     await checkImportStatus()
       .then(importStatus => {
         setImportProgress(importStatus);
@@ -435,16 +483,16 @@ const useGenomicVariantImportNotifications = () => {
   };
 
   const acknowledgeModelAndUpdateNotifications = async modelName => {
-    await acknowledgeImportStatus(modelName).then(_ => {
-      updateImportNotifications();
+    await acknowledgeImportStatus(modelName).then(async _ => {
+      await fetchImportStatus();
     }).catch(error => {
       showUnexpectedImportError(error);
     });
   };
 
   const acknowledgeBulkAndUpdateNotifications = async modelNames => {
-    await acknowledgeBulkImportStatus(modelNames).then(_ => {
-      updateImportNotifications();
+    await acknowledgeBulkImportStatus(modelNames).then(async _ => {
+      await fetchImportStatus();
     }).catch(error => {
       showUnexpectedImportError(error);
     });
@@ -452,16 +500,17 @@ const useGenomicVariantImportNotifications = () => {
 
   return {
     importNotifications: getImportNotifications(),
-    setImportNotifications,
     addImportNotification,
-    removeImportNotification,
-    showSuccessfulImportNotification,
     showErrorImportNotification,
     showUnexpectedImportError,
     updateNotificationsFromStatus,
-    updateImportNotifications,
+    fetchImportStatus,
     hideErrorImportNotification,
+    // resetBulkNonActionableImportErrors,
     importRunning: importProgress.running,
+    showBulkNonActionableImportErrors,
+    hideBulkNonActionableImportErrors,
+    getNonActionableImportErrorModels,
   };
 };
 

--- a/ui/src/components/admin/Notifications/NotificationsController.js
+++ b/ui/src/components/admin/Notifications/NotificationsController.js
@@ -1,20 +1,12 @@
 import React, { useState } from 'react';
-import { GDC_MODEL_STATES } from 'utils/constants';
+import uuid from 'uuid/v4';
+
+import {
+  DEFAULT_IMPORT_PROGRESS,
+  DEFAULT_NONACTIONABLE_IMPORTS,
+ } from 'utils/constants';
 
 export const NotificationsContext = React.createContext();
-
-const DEFAULT_IMPORT_PROGRESS = {
-  queue: [],
-  failed: [],
-  stopped: [],
-  success: [],
-  running: false,
-};
-
-const DEFAULT_NONACTIONABLE_IMPORTS = {
-  [GDC_MODEL_STATES.modelNotFound]: [],
-  [GDC_MODEL_STATES.noMafs]: [],
-};
 
 const NotificationsProvider = ({ children }) => {
   const [notifications, setNotifications] = useState([]);
@@ -26,18 +18,19 @@ const NotificationsProvider = ({ children }) => {
   const [nonactionableImports, setNonactionableImports] = useState(DEFAULT_NONACTIONABLE_IMPORTS);
 
   const appendNotification = notification => {
-    const id = Date.now();
+    const id = uuid();
     // default value is 10 seconds, can be overwritten or turned off (false)
     const timeout = 'timeout' in notification ? notification.timeout : 10000;
 
-    const clear = () => {
+    const clear = (useCallback = false) => {
       // removes the notification from notifications
       setNotifications(notifications => [
         ...notifications.filter(notification => notification.id !== id),
       ]);
 
-      // run optional onClose function
-      if (notification.onClose) {
+      // run optional onClose callback
+      // default is to NOT run the callback, must pass bool `true` to run
+      if (useCallback && notification.onClose) {
         notification.onClose();
       }
 
@@ -64,8 +57,9 @@ const NotificationsProvider = ({ children }) => {
     return notificationObj;
   };
 
+  // called when clicking the 'x' on a notification, ALWAYS runs onClose callback
   const clearNotification = id => {
-    notifications.find(notification => notification.id === id).clear();
+    notifications.find(notification => notification.id === id).clear(true);
   };
 
   return (

--- a/ui/src/components/admin/Notifications/ProgressBanner.js
+++ b/ui/src/components/admin/Notifications/ProgressBanner.js
@@ -27,7 +27,6 @@ import { Row, Col } from 'theme/system';
 import base from 'theme';
 
 import {
-  BULK_NONACTIONABLE_ERROR_ID,
   VARIANT_IMPORT_STATUS,
   VARIANT_IMPORT_TYPES,
 } from 'utils/constants';
@@ -46,7 +45,13 @@ const BulkImportState = {
 
 const ProgressBanner = ({ renderIcon }) => {
   const { importProgress } = useContext(NotificationsContext);
-  const { updateImportNotifications, showUnexpectedImportError, hideErrorImportNotification } = useGenomicVariantImportNotifications();
+  const {
+    fetchImportStatus,
+    showUnexpectedImportError,
+    hideErrorImportNotification,
+    hideBulkNonActionableImportErrors,
+    // resetBulkNonActionableImportErrors,
+  } = useGenomicVariantImportNotifications();
 
   const getBulkImports = () => {
     if (!importProgress) {
@@ -192,7 +197,7 @@ const ProgressBanner = ({ renderIcon }) => {
           confirmLabel: 'Yes, Stop',
           onConfirm: async () => {
             stopAllImports().then(_ => {
-              updateImportNotifications();
+              fetchImportStatus();
             }).catch(error => {
               showUnexpectedImportError(error);
             });
@@ -225,9 +230,10 @@ const ProgressBanner = ({ renderIcon }) => {
                   hideErrorImportNotification(model.modelName);
                 });
                 // Remove bulk nonactionable error notification
-                hideErrorImportNotification(BULK_NONACTIONABLE_ERROR_ID);
+                hideBulkNonActionableImportErrors();
               }
-              updateImportNotifications();
+              // resetBulkNonActionableImportErrors();
+              fetchImportStatus();
             }).catch(error => {
               showUnexpectedImportError(error);
             });

--- a/ui/src/components/admin/Notifications/ProgressBanner.js
+++ b/ui/src/components/admin/Notifications/ProgressBanner.js
@@ -50,7 +50,6 @@ const ProgressBanner = ({ renderIcon }) => {
     showUnexpectedImportError,
     hideErrorImportNotification,
     hideBulkNonActionableImportErrors,
-    // resetBulkNonActionableImportErrors,
   } = useGenomicVariantImportNotifications();
 
   const getBulkImports = () => {
@@ -232,7 +231,6 @@ const ProgressBanner = ({ renderIcon }) => {
                 // Remove bulk nonactionable error notification
                 hideBulkNonActionableImportErrors();
               }
-              // resetBulkNonActionableImportErrors();
               fetchImportStatus();
             }).catch(error => {
               showUnexpectedImportError(error);

--- a/ui/src/components/admin/helpers/notifications.js
+++ b/ui/src/components/admin/helpers/notifications.js
@@ -84,3 +84,20 @@ export function isEmptyResult(result) {
     ? true
     : false;
 }
+
+export const isEqual = (arr1, arr2) => {
+  if (!Array.isArray(arr1) || !Array.isArray(arr2) || arr1.length !== arr2.length) {
+    return false;
+  }
+
+  let sorted1 = arr1.sort();
+  let sorted2 = arr2.sort();
+
+  for (let i = 0; i < arr1.length; i++) {
+    if (sorted1[i] !== sorted2[i]) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/ui/src/components/modals/ConfirmMafFileModal.js
+++ b/ui/src/components/modals/ConfirmMafFileModal.js
@@ -140,7 +140,6 @@ const ConfirmMafFileModal = ({
         const existingNotification = notifications.find(x => x.modelName === modelName);
 
         if (existingNotification) {
-          existingNotification.onClose = null;
           existingNotification.clear();
         }
 
@@ -159,7 +158,7 @@ const ConfirmMafFileModal = ({
           details: error.message,
           timeout: false,
           modelName,
-          onClose: () => { acknowledgeImportStatus(modelName) },
+          onClose: () => acknowledgeImportStatus(modelName),
         });
       });
   };

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -27,6 +27,19 @@ const GDC_MODEL_STATES = {
   noNgcm: 'NO_NGCM',
 };
 
+const DEFAULT_IMPORT_PROGRESS = {
+  queue: [],
+  failed: [],
+  stopped: [],
+  success: [],
+  running: false,
+};
+
+const DEFAULT_NONACTIONABLE_IMPORTS = {
+  [GDC_MODEL_STATES.modelNotFound]: [],
+  [GDC_MODEL_STATES.noMafs]: [],
+};
+
 const GENOMIC_VARIANTS_IMPORT_ERRORS = {
   noMatchingModel: 'NO_MATCHING_MODEL',
   badRequest: 'BAD_REQUEST',
@@ -65,6 +78,8 @@ export {
   BULK_NONACTIONABLE_ERROR_ID,
   BULK_UPLOAD_DISPLAY_TYPES,
   BULK_UPLOAD_TYPES,
+  DEFAULT_IMPORT_PROGRESS,
+  DEFAULT_NONACTIONABLE_IMPORTS,
   GDC_CASE_URL_BASE,
   GDC_FILE_PAGE_URL_BASE,
   GDC_CANCER_MODEL_SAMPLE_TYPES,


### PR DESCRIPTION
Slightly a WIP, still working on fixes for two more issues:
* there is a brief moment when, after confirming a MAF file for a **bulk** import error, the error is dismissed but the state still has the error so the notification comes back for a few milliseconds before disappearing again
* similarly, for **individual** import errors, the above error can occur and prevent the model's variants table from refreshing after the import

Wanted to get this up quickly though to provide more time for code review.

Fixes the following:
* Fix inconsistencies in import error notifications not appearing or appearing multiple times by using the state as a single source of truth and ensuring unique ids with uuid
* Trigger a refresh of the Model Variants Table after resolving an import conflict for an individual model variant import