### PR TITLE
🐛 More Bulk Variant Import Bug Fixes (#900 #901)

### DIFF
--- a/ui/src/components/admin/Notifications/NotificationsController.js
+++ b/ui/src/components/admin/Notifications/NotificationsController.js
@@ -8,7 +8,7 @@ import {
 
 export const NotificationsContext = React.createContext();
 
-const NotificationsProvider = ({ children }) => {
+const NotificationsProvider = ({ location, children }) => {
   const [notifications, setNotifications] = useState([]);
   // only used for imports initiated from individual model pages
   const [importNotifications, setImportNotifications] = useState([]);
@@ -75,6 +75,7 @@ const NotificationsProvider = ({ children }) => {
         setImportProgress,
         nonactionableImports,
         setNonactionableImports,
+        location,
       }}
     >
       {children}

--- a/ui/src/components/admin/Notifications/ProgressBanner.js
+++ b/ui/src/components/admin/Notifications/ProgressBanner.js
@@ -46,8 +46,11 @@ const BulkImportState = {
 };
 
 const ProgressBanner = ({ renderIcon }) => {
-  const { refreshModelsTable } = useContext(ModelManagerContext);
-  const { importProgress } = useContext(NotificationsContext);
+  const { importProgress, location } = useContext(NotificationsContext);
+  const { refreshModelsTable } =
+    location && location.pathname === "/admin"
+      ? useContext(ModelManagerContext)
+      : { refreshModelsTable: null };
   const {
     fetchImportStatus,
     showUnexpectedImportError,
@@ -160,6 +163,7 @@ const ProgressBanner = ({ renderIcon }) => {
       }
 
       if (
+        refreshModelsTable &&
         (getImportState() === BulkImportState.complete ||
           getImportState() === BulkImportState.stopped) &&
         prevImportState.current === BulkImportState.importing
@@ -168,7 +172,7 @@ const ProgressBanner = ({ renderIcon }) => {
       }
 
       prevImportState.current = getImportState();
-    }, [importProgress, prevImportState]);
+    }, [importProgress, prevImportState, refreshModelsTable]);
 
     return (
       <Row>

--- a/ui/src/components/admin/VariantAudit/VariantAuditModal.js
+++ b/ui/src/components/admin/VariantAudit/VariantAuditModal.js
@@ -57,12 +57,14 @@ const VariantAuditModal = ({ bulkImportVariants }) => {
   const closeModal = () => modalState.setModalState({ component: null });
   const onImportAllChange = value => setImportAll(value);
   const onImportClick = async () => {
+    setLoading(true);
     const modelNames = normalizeOption(importAll)
       ? [...imported, ...clean]
       : [...clean];
 
     await bulkImportVariants(modelNames);
 
+    setLoading(false);
     closeModal();
   };
 

--- a/ui/src/components/admin/index.js
+++ b/ui/src/components/admin/index.js
@@ -7,7 +7,7 @@ import { LoggedInUserProvider } from '@hcmi-portal/ui/src/components/admin/servi
 import { VariantsProvider } from 'providers/Variants';
 
 export default ({ location }) => (
-  <NotificationsProvider>
+  <NotificationsProvider location={location}>
     <LoggedInUserProvider>
       <VariantsProvider>
         <AdminView location={location} />


### PR DESCRIPTION
🐛 Only attempt to refresh models table on Model Management page (#901)
* Fixes a bug where the Progress Banner would attempt to access context of the Model Management page on a different page, causing the page to crash

🐛 Disable Import Button on Variant Audit Modal While Loading (#900)
* Properly sets the `loading` state when beginning the import, preventing multiple imports from being triggered
