### PR TITLE
🐛 Bug Fixes from Release 1.10 Feedback (#908)

### DIFF
--- a/cms/src/routes/genomicVariants.js
+++ b/cms/src/routes/genomicVariants.js
@@ -210,8 +210,16 @@ variantsRouter.get('/audit', async (req, res) => {
   try {
     logger.debug(`Performing a genomic variant audit...`);
 
-    const imported = await Model.find({ genomic_variants: { $ne: [] } }, 'name');
-    const clean = await Model.find({ genomic_variants: [] }, 'name');
+    const imported = await Model.find(
+      { $and: [{ genomic_variants: { $exists: true } }, { genomic_variants: { $ne: [] } }] },
+      'name',
+    );
+    const clean = await Model.find(
+      {
+        $or: [{ genomic_variants: { $exists: false } }, { genomic_variants: [] }],
+      },
+      'name',
+    );
 
     return res.status(200).json({
       imported: imported.map(i => i.name),

--- a/cms/src/services/gdc-importer/mafFiles.js
+++ b/cms/src/services/gdc-importer/mafFiles.js
@@ -137,8 +137,12 @@ export const fetchModelFileData = async modelNames => {
             })
             .map(entity => {
               const matchingSample = samples.find(sample => sample.aliquots.includes(entity));
+              const matchingEntity = get(fileEdge, 'node.associated_entities.hits.edges', []).find(
+                x => x.node.entity_id === entity,
+              );
               return {
                 entityId: entity,
+                entitySubmitterId: get(matchingEntity, 'node.entity_submitter_id'),
                 sampleType: matchingSample.sampleType,
                 tissueType: matchingSample.tissueType,
                 tumorDescriptor: matchingSample.tumorDescriptor,

--- a/ui/src/components/modals/ConfirmMafFileModal.js
+++ b/ui/src/components/modals/ConfirmMafFileModal.js
@@ -130,7 +130,7 @@ const ConfirmMafFileModal = ({
         sampleType: entity.sampleType,
         tissueType: entity.tissueType,
         tumorDescriptor: entity.tumorDescriptor,
-        entityId: entity.entityId,
+        entityId: entity.entitySubmitterId,
       };
     });
   };


### PR DESCRIPTION
🐛 Use Entity Submitter ID as Entity ID (#908)
* Fixes a bug where the wrong Entity ID was being displayed in the Confirm MAF File modal

🐛 Account for models created before genomic variant support was added in Audit (#908)
* Fixes a bug where models created before genomic variants were added to the model would be incorrectly classified by the genomic variant audit