### PR TITLE
⚡️ Reduce logging to improve CMS performance (#904)

### DIFF
--- a/cms/src/helpers/dictionary.js
+++ b/cms/src/helpers/dictionary.js
@@ -148,7 +148,11 @@ export const publishDraft = async () => {
     });
     if (edited) {
       model.save();
-      logger.audit({ model }, 'model saved', 'Model values updated due to dictionary publish');
+      logger.audit(
+        { model: model.name },
+        'model saved',
+        'Model values updated due to dictionary publish',
+      );
       updatedModels += 1;
     }
   });

--- a/cms/src/helpers/genomicVariants.js
+++ b/cms/src/helpers/genomicVariants.js
@@ -166,7 +166,14 @@ export const addGenomicVariantsFromMaf = async (name, mafData, { filename, fileI
         : modelStatus.unpublishedChanges;
 
     await model.save();
-    logger.audit({ model }, 'model saved', 'Genomic Variants added to model');
+    logger.audit(
+      {
+        model: model.name,
+        genomic_variants: model.genomic_variants ? model.genomic_variants.length : 0,
+      },
+      'model saved',
+      'Genomic Variants added to model',
+    );
   } else {
     logger.warn({ name }, 'Could not find model for genomic variant import');
     throw new Error('Model could not be found');

--- a/cms/src/helpers/matchedModels.js
+++ b/cms/src/helpers/matchedModels.js
@@ -23,7 +23,7 @@ const createMatchedModels = async models => {
         ? modelStatus.unpublished
         : modelStatus.unpublishedChanges;
     model.save();
-    logger.audit({ model }, 'model saved', 'Model updated to add matched model set');
+    logger.audit({ model: model.name }, 'model saved', 'Model updated to add matched model set');
   }
   return matchedModels;
 };
@@ -64,7 +64,7 @@ const clearModelFromSets = async model => {
             : modelStatus.unpublishedChanges;
         await otherModel.save();
         logger.audit(
-          { model: otherModel },
+          { model: otherModel.name },
           'model saved',
           'Model updated to remove matched model set',
         );
@@ -92,7 +92,7 @@ const clearModelFromSets = async model => {
       ? modelStatus.unpublished
       : modelStatus.unpublishedChanges;
   await model.save();
-  logger.audit({ model }, 'model saved', 'Model updated to remove matched model set');
+  logger.audit({ model: model.name }, 'model saved', 'Model updated to remove matched model set');
 
   return;
 };
@@ -165,7 +165,7 @@ const connectWithMatchedModels = async (nameToAdd, setMemberName) => {
           : modelStatus.unpublishedChanges;
       await modelToAdd.save();
       logger.audit(
-        { model: modelToAdd },
+        { model: modelToAdd.name },
         'model saved',
         'Model updated to add to matched model set',
       );

--- a/cms/src/hooks.js
+++ b/cms/src/hooks.js
@@ -105,7 +105,7 @@ export const postUpdate = async (req, res, next) => {
     },
   } = req;
 
-  logger.audit({ model: result }, 'model saved', 'Model saved in mongo');
+  logger.audit({ model: modelName }, 'model saved', 'Model saved in mongo');
 
   // Model updates that contain the status key we
   // treat as being a change in status and trigger

--- a/cms/src/services/elastic-search/publish.js
+++ b/cms/src/services/elastic-search/publish.js
@@ -50,7 +50,7 @@ export const indexOneToES = filter => {
                   resolve({
                     status: `Indexing successful with status: ${res.result}`,
                   });
-                logger.audit({ model: doc }, 'publish model', 'Model Published to ES');
+                logger.audit({ model: doc.name }, 'publish model', 'Model Published to ES');
               }
             });
           })


### PR DESCRIPTION
* Log only model name instead of the full model on CMS updates
* Log the number of genomic variants added/removed instead of the full list