### PR TITLE
♿️ Accessibility Improvements (#880)

### DIFF
--- a/ui/src/components/Header.js
+++ b/ui/src/components/Header.js
@@ -2,16 +2,18 @@ import React from 'react';
 
 import { useExpandedUnexpanded } from 'providers/ExpandedUnexpanded';
 
-import { Header, HeaderLink, subheadingStyle } from 'theme/headerStyles';
+import { Header, HeaderLinkWrapper, HeaderLink, subheadingStyle } from 'theme/headerStyles';
 
 export default ({ subheading = 'Searchable Catalog' }) => {
   const { resetShowUnexpanded } = useExpandedUnexpanded();
 
   return (
     <Header>
-      <HeaderLink onClick={() => resetShowUnexpanded()} to="/">
-        Human Cancer Models Initiative
-      </HeaderLink>
+      <HeaderLinkWrapper>
+        <HeaderLink onClick={() => resetShowUnexpanded()} to="/">
+          Human Cancer Models Initiative
+        </HeaderLink>
+      </HeaderLinkWrapper>
       <div css={subheadingStyle}>{subheading}</div>
     </Header>
   );

--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -155,7 +155,7 @@ const MolecularCharacterizationsTable = ({ characterizations }) => {
     <table className="molecular-characterizations-table">
       <tbody>
         <tr>
-          <th />
+          <td />
           <th>Model</th>
           <th>Tumor</th>
           <th>Normal</th>

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -63,7 +63,7 @@ export default ({
           onDragStarted={() => (stable = false)}
           onDragFinished={() => (stable = true)}
         >
-          <Col className="aggregations-wrapper">
+          <Col className="aggregations-wrapper" role="complementary">
             <Component shouldUpdate={() => stable}>
               {() => (
                 <>
@@ -135,6 +135,7 @@ export default ({
                 justify-content: space-around;
                 border: 1px solid #d9d9df;
               `}
+              aria-hidden={true}
             >
               <Component shouldUpdate={() => stable}>
                 {() => (

--- a/ui/src/theme/headerStyles.js
+++ b/ui/src/theme/headerStyles.js
@@ -26,6 +26,11 @@ export const Header = styled('header')`
   padding: 0 16px 12px 13px;
 `;
 
+export const HeaderLinkWrapper = styled('h1')`
+  margin: unset;
+  font-size: unset;
+`;
+
 export const HeaderLink = styled(Link)`
   font-family: ${openSans};
   font-size: 32px;


### PR DESCRIPTION
♿️ Improve a11y of Molecular Characterizations Table (#880)
* Fixes an issue with an empty table header

♿️ Ensure appropriate heading levels are used (#880)
* Fixes an a11y issue where pages were missing a level 1 heading

♿️ Fix remaining Search page a11y issues (#880)
* Add landmark role for Search facets sidebar
* Hide nivo charts from screen readers, the library still isn't accessible