### PR TITLE
✨ Generate GDC URLs on Variant Import (#913)

### DIFF
--- a/cms/src/helpers/genomicVariants.js
+++ b/cms/src/helpers/genomicVariants.js
@@ -66,6 +66,7 @@ const buildVariantId = ({
 
 const buildModelUrl = caseId => `${BASE_GDC_URL}/cases/${caseId}`;
 const buildMafUrl = fileId => `${BASE_GDC_URL}/files/${fileId}`;
+// URL encoded: /repository?facetTab=files&filters={"op":"and","content":[{"op":"in","content":{"field":"cases.case_id","value":["caseId"]}}]}&searchTableTab=files
 const buildSequenceUrl = caseId =>
   `${BASE_GDC_URL}/repository?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases.case_id%22%2C%22value%22%3A%5B%22${caseId}%22%5D%7D%7D%5D%7D&searchTableTab=files`;
 

--- a/cms/src/services/gdc-importer/gdcConstants.js
+++ b/cms/src/services/gdc-importer/gdcConstants.js
@@ -135,3 +135,5 @@ export const FETCH_MODEL_FILE_DATA_QUERY = `query ($filter: FiltersArgument, $si
     }
   }
 }`;
+
+export const BASE_GDC_URL = 'https://portal.gdc.cancer.gov';


### PR DESCRIPTION
* Make use of the `caseId` and `fileId` when performing a variant import to automatically save the Model URL, Sequence URL, and Somatic MAF URL