### PR TITLE
✨ Add Info Tooltips to Arranger Facet Headers (#907)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@arranger/components": "2.12.17",
+    "@arranger/components": "2.13.0",
     "@hcmi-portal/cms": "0.0.1",
     "@nivo/bar": "^0.52.0",
     "@nivo/pie": "^0.52.0",

--- a/ui/src/components/modals/ModelListModal.js
+++ b/ui/src/components/modals/ModelListModal.js
@@ -5,7 +5,6 @@ import moment from 'moment-timezone';
 
 import ModelListModalQuery from 'components/queries/ModelListModalQuery';
 import cartDownload from 'utils/cartDownload';
-import modelExportProcessor from 'utils/modelExportProcessor';
 import modelImageProcessor from 'utils/modelImageProcessor';
 import { SelectedModelsContext } from 'providers/SelectedModels';
 import { ModalStateContext } from 'providers/ModalState';

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -70,7 +70,7 @@ export default ({
           onDragFinished={() => (stable = true)}
         >
           <Col className="aggregations-wrapper" role="complementary">
-            <Component shouldUpdate={() => stable}>
+            <Component>
               {() => (
                 <>
                   <ModelSearch sqon={toggleExpanded(sqon, showUnexpanded)} setSQON={setSQON} />
@@ -86,6 +86,35 @@ export default ({
                       getTermAggProps: () => ({ maxTerms: 4 }),
                       InputComponent: TextInput,
                     }}
+                    customFacets={[
+                      {
+                        content: {
+                          field: 'genomic_variants.classification',
+                          displayName: <Row justifyContent="space-between">
+                          Research Somatic Variant Type
+                          <GenomicVariantsTooltip isFacet={true} width={state.panelSize - 30} />
+                        </Row>,
+                        },
+                      },
+                      {
+                        content: {
+                          field: 'has_matched_models',
+                          displayName: <Row justifyContent="space-between">
+                          Has Multiple Models
+                          <MultipleModelsTooltip isFacet={true} width={state.panelSize - 30} />
+                        </Row>,
+                        },
+                      },
+                      {
+                        content: {
+                          field: 'molecular_characterizations',
+                          displayName: <Row justifyContent="space-between">
+                          Available Molecular Characterizations
+                          <MolecularCharacterizationsTooltip isFacet={true} width={state.panelSize - 30} />
+                        </Row>,
+                        },
+                      },
+                    ]}
                   />
                 </>
               )}
@@ -281,7 +310,7 @@ export default ({
                               field: 'matched_models_list',
                               displayName: 'Has Multiple Models',
                               Header: () => (
-                                <Row space="space-between">
+                                <Row justifyContent="space-between">
                                   Has Multiple Models <MultipleModelsTooltip isColumn={true} />
                                 </Row>
                               ),
@@ -292,7 +321,7 @@ export default ({
                               field: 'molecular_characterizations',
                               displayName: 'Available Molecular Characterizations',
                               Header: () => (
-                                <Row space="space-between">
+                                <Row justifyContent="space-between">
                                   Available Molecular Characterizations
                                   <MolecularCharacterizationsTooltip isColumn={true} />
                                 </Row>
@@ -304,7 +333,7 @@ export default ({
                               field: 'gene_metadata.genomic_variant_count',
                               displayName: '# Research Somatic Variants',
                               Header: () => (
-                                <Row space="space-between">
+                                <Row justifyContent="space-between">
                                   # Research Somatic Variants
                                   <GenomicVariantsTooltip />
                                 </Row>
@@ -316,7 +345,7 @@ export default ({
                               field: 'gene_metadata.clinical_variant_count',
                               displayName: '# Clinical Variants',
                               Header: () => (
-                                <Row space="space-between">
+                                <Row justifyContent="space-between">
                                   # Clinical Variants
                                   <ClinicalVariantsTooltip />
                                 </Row>
@@ -328,7 +357,7 @@ export default ({
                               field: 'gene_metadata.histopathological_variant_count',
                               displayName: '# Histo-pathological Biomarkers',
                               Header: () => (
-                                <Row space="space-between">
+                                <Row justifyContent="space-between">
                                   # Histo-pathological Biomarkers
                                   <HistopathologicalBiomarkersTooltip />
                                 </Row>

--- a/ui/src/components/tooltips/InfoTooltip.js
+++ b/ui/src/components/tooltips/InfoTooltip.js
@@ -9,6 +9,7 @@ const InfoTooltip = ({
   iconStyle,
   infoStyle = {},
   position = 'top right',
+  width = '380px',
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -47,8 +48,9 @@ const InfoTooltip = ({
       onClose={hideTooltip}
       position={position}
       contentStyle={{
-        width: '380px',
+        width: width || '380px',
         zIndex: 100,
+        transform: 'translate3d(0, 0, 0)',
         ...infoStyle,
       }}
       mouseEnterDelay={100}

--- a/ui/src/components/tooltips/index.js
+++ b/ui/src/components/tooltips/index.js
@@ -4,6 +4,10 @@ import InfoTooltip from './InfoTooltip';
 import { TooltipLink } from 'theme/modelStyles';
 
 const resetIconPositionStyle = `position: relative; top: unset; right: unset; margin-bottom: auto;`;
+const resetFacetIconPositionStyle = `
+  ${resetIconPositionStyle}
+  margin: auto 0 auto 5px;
+`;
 
 export const ModelDetailsTooltip = () => (
   <InfoTooltip
@@ -16,26 +20,36 @@ export const ModelDetailsTooltip = () => (
   </InfoTooltip>
 );
 
-export const MultipleModelsTooltip = ({ isColumn = false }) => (
+export const MultipleModelsTooltip = ({ isColumn = false, isFacet = false, width = null }) => (
   <InfoTooltip
     ariaLabel={
       'In some cases, it is possible to create models from more than one tumor site from a single patient. These Multiple Models for a single patient are associated with each other.'
     }
-    position={isColumn ? 'bottom right' : undefined}
-    iconStyle={isColumn ? resetIconPositionStyle : undefined}
+    position={isColumn || isFacet ? 'bottom right' : undefined}
+    iconStyle={
+      isColumn ? resetIconPositionStyle : isFacet ? resetFacetIconPositionStyle : undefined
+    }
+    width={width ? width : undefined}
   >
     In some cases, it is possible to create models from more than one tumor site from a single
     patient. These <b>Multiple Models</b> for a single patient are associated with each other.
   </InfoTooltip>
 );
 
-export const MolecularCharacterizationsTooltip = ({ isColumn }) => (
+export const MolecularCharacterizationsTooltip = ({
+  isColumn = false,
+  isFacet = false,
+  width = null,
+}) => (
   <InfoTooltip
     ariaLabel={
       'QC’ed data are released as they complete the characterization pipeline. Available data types may differ among Cancer Model Development Centers.'
     }
-    position={isColumn ? 'bottom right' : undefined}
-    iconStyle={isColumn ? resetIconPositionStyle : undefined}
+    position={isColumn || isFacet ? 'bottom right' : undefined}
+    iconStyle={
+      isColumn ? resetIconPositionStyle : isFacet ? resetFacetIconPositionStyle : undefined
+    }
+    width={width ? width : undefined}
   >
     QC’ed data are released as they complete the characterization pipeline.{' '}
     <b> Available data types</b> may differ among Cancer Model Development Centers.
@@ -101,13 +115,14 @@ export const HistopathologicalBiomarkersTooltip = () => (
   </InfoTooltip>
 );
 
-export const GenomicVariantsTooltip = () => (
+export const GenomicVariantsTooltip = ({ isFacet = false, width = null }) => (
   <InfoTooltip
     ariaLabel={
       'Variants are imported from GDC and are identified from filtered, open-access MAFs. Controlled-access data at GDC requires dbGaP approval; see GDC for details.'
     }
     position="bottom right"
-    iconStyle={resetIconPositionStyle}
+    iconStyle={isFacet ? resetFacetIconPositionStyle : resetIconPositionStyle}
+    width={width ? width : undefined}
   >
     <b>Variants</b> are imported from GDC and are identified from filtered, open-access MAFs.
     Controlled-access data at GDC requires dbGaP approval;{' '}

--- a/ui/src/theme/searchStyles.js
+++ b/ui/src/theme/searchStyles.js
@@ -530,6 +530,10 @@ export default css`
     height: 8px;
   }
 
+  .aggregations .aggregation-card .header {
+    position: relative;
+  }
+
   .aggregation-card .header .title-wrapper {
     padding: 10px;
     background-image: linear-gradient(to bottom, ${athensGray} 9%, ${athensLightGray} 91%);
@@ -674,6 +678,16 @@ export default css`
 
   .aggregation-card .bucket .toggle-button .toggle-button-option.active {
     background-color: ${linen};
+  }
+
+  .aggregations .aggregation-card .title-wrapper {
+    .title-control {
+      width: 100%;
+
+      .title {
+        width: 100%;
+      }
+    }
   }
 
   .model-name-search-wrapper .title-wrapper {

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,12 +72,12 @@
     ramda "^0.26.1"
     tslib "^1.10.0"
 
-"@arranger/components@2.12.17":
-  version "2.12.17"
-  resolved "https://registry.yarnpkg.com/@arranger/components/-/components-2.12.17.tgz#01de6e6700b3224e29fdc1f128ee0a76ae6c7698"
-  integrity sha512-cDPjW2xubfvsbsg7f13mxaUSVYTU+WOOsfrGOKs2bRflW3FphTBmBWRO9c0vJrbyEGqAk2cwDt+LctSgvoH39Q==
+"@arranger/components@2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@arranger/components/-/components-2.13.0.tgz#9e64d76722e5628a7211c82107f8589925a616a8"
+  integrity sha512-jCWZd6fe/rv+fH0YiIK31NEjpJGExQKyVfgO02qUW8Hlj1F7BVj4egf+BTU0x1Nuvh2a04lY+x62+OnbtEXigw==
   dependencies:
-    "@arranger/mapping-utils" "^2.12.17"
+    "@arranger/mapping-utils" "^2.13.0"
     ajv "^6.1.1"
     babel-polyfill "^6.26.0"
     classnames "^2.2.5"
@@ -131,10 +131,40 @@
     node-fetch "^2.2.0"
     uuid "^3.2.1"
 
+"@arranger/mapping-utils@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@arranger/mapping-utils/-/mapping-utils-2.13.0.tgz#dd598fbf79e30be5071d6fdf08bb00db8cfdb00a"
+  integrity sha512-GyduLvpm+VXxfgLWCICsxcINxikTQDtBQBP8WjWdYGBdjWv1LVx/7l+AA4Ui2IJxWDnDiIq3Uz0BshOO9iOfRw==
+  dependencies:
+    "@arranger/middleware" "^2.13.0"
+    babel-polyfill "^6.26.0"
+    graphql-fields "^1.0.2"
+    kind-of "^6.0.3"
+    lodash "^4.17.20"
+    minimist "^1.2.5"
+    node-fetch "^2.2.0"
+    uuid "^3.2.1"
+
 "@arranger/middleware@^2.12.17":
   version "2.12.17"
   resolved "https://registry.yarnpkg.com/@arranger/middleware/-/middleware-2.12.17.tgz#693ddf6ce91c6d0c384406ede1145daa11ff3ab3"
   integrity sha512-ozFgb8fHFPqeryJ1HANF6svdeI5Cat3qCTA1rB4rh7rppMXeCt57aG6/p8/2pI/ZrvcVlVXABsDFbGNGy15qZA==
+  dependencies:
+    body-parser "^1.18.2"
+    cors "^2.8.4"
+    date-fns "^1.29.0"
+    express "^4.16.3"
+    kind-of "^6.0.3"
+    lodash "^4.17.20"
+    minimist "^1.2.5"
+    morgan "^1.9.0"
+    utf8 "^3.0.0"
+    winston "^2.4.0"
+
+"@arranger/middleware@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@arranger/middleware/-/middleware-2.13.0.tgz#5c3454dec88095ce5ae8718d711f42b706475786"
+  integrity sha512-3rsR7bzL3cbrqnf40xmw/W3U6lZwZPjmXOYlQUJreZKEDhG7+sX9/J0H9QNsfR8C3318a6T1T4rKojUc0SFPfQ==
   dependencies:
     body-parser "^1.18.2"
     cors "^2.8.4"


### PR DESCRIPTION
### Commits:
**⬆️ Upgrade Arranger to v2.13.0 (#907)**
* Upgrades @arranger/components to v2.13.0 for custom facet header support

**🗑️ Remove unused import**
* Removes an unused import from ModelListModal to prevent linter warnings

**✨ Add Info Tooltips to Arranger Facet Headers (#907)**
* Adds "hover bubbles" to: Research Somatic Variant Type, Has Multiple Models, and Available Molecular Characterizations facet headers