### PR TITLE
✨ Add Info Tooltip to Expansion Status Column

### DIFF
--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -31,6 +31,7 @@ import {
   ClinicalVariantsTooltip,
   HistopathologicalBiomarkersTooltip,
   GenomicVariantsTooltip,
+  ExpansionStatusTooltip,
 } from 'components/tooltips';
 
 import { useExpandedUnexpanded } from 'providers/ExpandedUnexpanded';
@@ -253,7 +254,7 @@ export default ({
                           age_at_sample_acquisition: { minWidth: 85 },
                           genes_count: { minWidth: 69 },
                           number: { minWidth: 88 },
-                          expanded: { minWidth: 80 },
+                          expanded: { minWidth: 105 },
                           histo_variant_count: { minWidth: 108 },
                           matched_models: { minWidth: 84 },
                         }}
@@ -283,6 +284,17 @@ export default ({
                               Header: () => (
                                 <Row space="space-between">
                                   Has Multiple Models <MultipleModelsTooltip isColumn={true} />
+                                </Row>
+                              ),
+                            },
+                          },
+                          {
+                            content: {
+                              field: 'expanded',
+                              displayName: 'Expansion Status',
+                              Header: () => (
+                                <Row space="space-between">
+                                  Expansion Status <ExpansionStatusTooltip />
                                 </Row>
                               ),
                             },

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -293,7 +293,7 @@ export default ({
                               field: 'expanded',
                               displayName: 'Expansion Status',
                               Header: () => (
-                                <Row space="space-between">
+                                <Row justifyContent="space-between">
                                   Expansion Status <ExpansionStatusTooltip />
                                 </Row>
                               ),

--- a/ui/src/components/tooltips/index.js
+++ b/ui/src/components/tooltips/index.js
@@ -121,3 +121,18 @@ export const GenomicVariantsTooltip = () => (
     for details.
   </InfoTooltip>
 );
+
+export const ExpansionStatusTooltip = () => (
+  <InfoTooltip
+    ariaLabel={
+      'Expanded models are available for purchase on ATCC. Unexpanded models have passed sequencing validation QC, but are not yet available for purchase.'
+    }
+    position="bottom right"
+    iconStyle={resetIconPositionStyle}
+  >
+    <b>Expanded models</b> are available for purchase on ATCC.
+    <br />
+    <b>Unexpanded models</b> have passed sequencing validation QC, but are not yet available for
+    purchase.
+  </InfoTooltip>
+);


### PR DESCRIPTION
Adds a hover bubble for the "Expansion Status" column of the Search table