### PR TITLE
✨ Manual MAF Import Override (#936)

### DIFF
--- a/cms/src/routes/genomicVariants.js
+++ b/cms/src/routes/genomicVariants.js
@@ -137,13 +137,15 @@ variantsRouter.post('/import/bulk', async (req, res) => {
 
 variantsRouter.post('/import/:name', async (req, res) => {
   const { name } = req.params;
+  const { fileId = null, filename = null } = req.body;
+
   try {
     logger.debug(`Beginning genomic-variant import for model ${name}`);
 
     // Clear first before importing new
     await clearGenomicVariants(name);
 
-    const result = await VariantImporter.queueImport(name);
+    const result = await VariantImporter.queueImport(name, fileId, filename);
 
     if (result.error) {
       return res.status(400).json({ success: false, error: result.error });

--- a/cms/src/services/gdc-importer/VariantImporter.js
+++ b/cms/src/services/gdc-importer/VariantImporter.js
@@ -138,7 +138,13 @@ const Import = ({
         { time: Date.now(), startTime, fileId, filename, modelName },
         'Beginning MAF file download...',
       );
-      const mafFile = await downloadMaf({ filename, fileId, modelName });
+      const mafFile = await downloadMaf({ filename, fileId, modelName }).catch(error => {
+        errorStop({
+          code: IMPORT_ERRORS.manualImportError,
+          message: error.message,
+          error,
+        });
+      });
 
       if (status !== ImportStatus.active) {
         return;

--- a/cms/src/services/gdc-importer/gdcConstants.js
+++ b/cms/src/services/gdc-importer/gdcConstants.js
@@ -16,6 +16,8 @@ export const IMPORT_ERRORS = {
   gdcCommunicationError: 'GDC_COMMUNICATION_ERROR',
   // Unexpected error
   unexpected: 'UNEXPECTED',
+  // Manual import error
+  manualImportError: 'MANUAL_IMPORT_ERROR',
 };
 
 export const IMPORT_OVERWRITE_OPTIONS = {

--- a/ui/src/components/admin/Model/ModelVariants.js
+++ b/ui/src/components/admin/Model/ModelVariants.js
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import moment from 'moment-timezone';
+import Popup from 'reactjs-popup';
 
 import { ModelSingleContext } from './ModelSingleController';
 import { ModalStateContext } from 'providers/ModalState';
@@ -15,11 +16,13 @@ import BulkUploader from '../BulkUpload';
 import { ModelVariantColumns as clinicalVariantTableColumns } from './ModelVariantColumns';
 import { ModelGenomicVariantColumns as genomicVariantTableColumns } from './ModelGenomicVariantColumns';
 import { TabGroup, Tab } from 'components/layout/HorizontalTabs';
+import CollapsibleArrow from 'icons/CollapsibleArrow';
 import PlusIcon from 'icons/PlusIcon';
 import VariantsIcon from 'icons/VariantsIcon';
 import TabHeader from './TabHeader';
 import useConfirmationModal from 'components/modals/ConfirmationModal';
 
+import { DropdownItem } from 'theme/adminNavStyles';
 import { AdminContainer, AdminHeader, AdminHeaderH3, AdminHeaderBlock } from 'theme/adminStyles';
 import { ButtonPill } from 'theme/adminControlsStyles';
 import { Table, ToolbarHeader } from 'theme/adminTableStyles';
@@ -171,6 +174,7 @@ export default ({ data: { name, gene_metadata, genomic_variants, variants, updat
   const importStatus = useRef(null);
   const { fetchGenomicVariantData } = useContext(ModelSingleContext);
   const [activeTab, setActiveTab] = useState(null);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
   const {
     importNotifications,
     addImportNotification,
@@ -256,34 +260,54 @@ export default ({ data: { name, gene_metadata, genomic_variants, variants, updat
                         <PlusIcon css={'margin-right: 5px;'} />
                         Clinical Variants
                       </ButtonPill>
-                      {useConfirmationModal({
-                        title: 'Overwrite Existing Variants?',
-                        message:
-                          'Are you sure you want to import new research variants and overwrite the existing list?',
-                        confirmLabel: 'Yes, Import',
-                        onConfirm: () => {
-                          importGenomicVariants(name)
-                            .then(async _ => {
-                              await addImportNotification(name);
-                            })
-                            .catch(error => {
-                              const data = error.response ? error.response.data : error;
-                              showErrorImportNotification(name, data);
-                            });
-                        },
-                        confirmationRequired: genomicVariantsData.length > 0,
-                      })(
-                        <ButtonPill
-                          primary
-                          css={'margin-left: 10px;'}
-                          disabled={importNotifications.find(
-                            notification => notification.modelName === name,
-                          )}
-                        >
-                          <PlusIcon css={'margin-right: 5px;'} />
-                          Research Somatic Variants
-                        </ButtonPill>,
-                      )}
+                      <Popup
+                        trigger={() => (
+                          <div>
+                            <ButtonPill
+                              primary
+                              css={'margin-left: 10px;'}
+                              disabled={importNotifications.find(
+                                notification => notification.modelName === name,
+                              )}
+                              onClick={() => setDropdownOpen(!dropdownOpen)}
+                            >
+                              <PlusIcon css={'margin-right: 5px;'} />
+                              Research Somatic Variants
+                              <CollapsibleArrow
+                                isOpen={dropdownOpen}
+                                colour={'#000'}
+                                weight={4}
+                                css={`
+                                  margin-left: 4px;
+                                `}
+                              />
+                            </ButtonPill>
+                          </div>
+                        )}
+                        offset={0}
+                        open={dropdownOpen}
+                        arrow={false}
+                        onClose={() => setDropdownOpen(false)}
+                      >
+                        {useConfirmationModal({
+                          title: 'Overwrite Existing Variants?',
+                          message:
+                            'Are you sure you want to import new research variants and overwrite the existing list?',
+                          confirmLabel: 'Yes, Import',
+                          onConfirm: () => {
+                            importGenomicVariants(name)
+                              .then(async _ => {
+                                await addImportNotification(name);
+                              })
+                              .catch(error => {
+                                const data = error.response ? error.response.data : error;
+                                showErrorImportNotification(name, data);
+                              });
+                          },
+                          confirmationRequired: genomicVariantsData.length > 0,
+                        })(<DropdownItem>Automatic Import from GDC</DropdownItem>)}
+                        <DropdownItem>Manual Import from GDC</DropdownItem>
+                      </Popup>
                     </>
                   )}
                 </ModalStateContext.Consumer>

--- a/ui/src/components/admin/Model/ModelVariants.js
+++ b/ui/src/components/admin/Model/ModelVariants.js
@@ -21,6 +21,7 @@ import PlusIcon from 'icons/PlusIcon';
 import VariantsIcon from 'icons/VariantsIcon';
 import TabHeader from './TabHeader';
 import useConfirmationModal from 'components/modals/ConfirmationModal';
+import withManualImportMafModal from 'components/modals/ManualImportMafModal';
 
 import { DropdownItem } from 'theme/adminNavStyles';
 import { AdminContainer, AdminHeader, AdminHeaderH3, AdminHeaderBlock } from 'theme/adminStyles';
@@ -289,24 +290,29 @@ export default ({ data: { name, gene_metadata, genomic_variants, variants, updat
                         arrow={false}
                         onClose={() => setDropdownOpen(false)}
                       >
-                        {useConfirmationModal({
-                          title: 'Overwrite Existing Variants?',
-                          message:
-                            'Are you sure you want to import new research variants and overwrite the existing list?',
-                          confirmLabel: 'Yes, Import',
-                          onConfirm: () => {
-                            importGenomicVariants(name)
-                              .then(async _ => {
-                                await addImportNotification(name);
-                              })
-                              .catch(error => {
-                                const data = error.response ? error.response.data : error;
-                                showErrorImportNotification(name, data);
-                              });
-                          },
-                          confirmationRequired: genomicVariantsData.length > 0,
-                        })(<DropdownItem>Automatic Import from GDC</DropdownItem>)}
-                        <DropdownItem>Manual Import from GDC</DropdownItem>
+                        <>
+                          {useConfirmationModal({
+                            title: 'Overwrite Existing Variants?',
+                            message:
+                              'Are you sure you want to import new research variants and overwrite the existing list?',
+                            confirmLabel: 'Yes, Import',
+                            onConfirm: () => {
+                              importGenomicVariants(name)
+                                .then(async _ => {
+                                  await addImportNotification(name);
+                                })
+                                .catch(error => {
+                                  const data = error.response ? error.response.data : error;
+                                  showErrorImportNotification(name, data);
+                                });
+                            },
+                            confirmationRequired: genomicVariantsData.length > 0,
+                          })(<DropdownItem size={12}>Automatic Import from GDC</DropdownItem>)}
+                          {withManualImportMafModal({
+                            modelName: name,
+                            onConfirm: async () => await addImportNotification(name),
+                          })(<DropdownItem size={12}>Manual Import from GDC</DropdownItem>)}
+                        </>
                       </Popup>
                     </>
                   )}

--- a/ui/src/components/admin/Model/actions/GenomicVariants.js
+++ b/ui/src/components/admin/Model/actions/GenomicVariants.js
@@ -13,7 +13,7 @@ export const importBulkGenomicVariants = async models => {
   return post({
     url,
     data: {
-      models
+      models,
     },
   });
 };
@@ -23,17 +23,17 @@ export const auditGenomicVariantsAllModels = async () => {
   return get({
     url,
   });
-}
+};
 
 export const auditGenomicVariantsSpecificModels = async models => {
   const url = `${GENOMIC_VARIANTS_URL}/audit`;
   return post({
     url,
     data: {
-      models
+      models,
     },
   });
-}
+};
 
 export const clearGenomicVariants = async modelName => {
   return new Promise(async (resolve, reject) => {
@@ -80,15 +80,15 @@ export const acknowledgeBulkImportStatus = async models => {
     await post({
       url,
       data: {
-        models
+        models,
       },
     })
-    .then(res => {
-      resolve(res.data);
-    })
-    .catch(err => {
-      reject(err.response ? err.response.data.error : err);
-    });
+      .then(res => {
+        resolve(res.data);
+      })
+      .catch(err => {
+        reject(err.response ? err.response.data.error : err);
+      });
   });
 };
 
@@ -103,12 +103,12 @@ export const resolveMafFileConflict = async (modelName, fileId, filename) => {
         filename: filename,
       },
     })
-    .then(res => {
-      resolve(res.data);
-    })
-    .catch(err => {
-      reject(err.response ? err.response.data.error : err);
-    });
+      .then(res => {
+        resolve(res.data);
+      })
+      .catch(err => {
+        reject(err.response ? err.response.data.error : err);
+      });
   });
 };
 
@@ -116,6 +116,25 @@ export const stopAllImports = async () => {
   return new Promise(async (resolve, reject) => {
     const url = `${GENOMIC_VARIANTS_URL}/stop/all`;
     await post({ url })
+      .then(res => {
+        resolve(res.data);
+      })
+      .catch(err => {
+        reject(err.response ? err.response.data.error : err);
+      });
+  });
+};
+
+export const manualMafImport = async (modelName, fileId, filename) => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${GENOMIC_VARIANTS_URL}/import/${modelName}`;
+    await post({
+      url,
+      data: {
+        fileId: fileId,
+        filename: filename,
+      },
+    })
       .then(res => {
         resolve(res.data);
       })

--- a/ui/src/components/admin/Notifications/GenomicVariantImportNotifications.js
+++ b/ui/src/components/admin/Notifications/GenomicVariantImportNotifications.js
@@ -315,6 +315,17 @@ const useGenomicVariantImportNotifications = () => {
           onClose: () => { acknowledgeModelAndUpdateNotifications(modelName) },
         });
         break;
+      case GENOMIC_VARIANTS_IMPORT_ERRORS.manualImportError:
+        appendNotification({
+          type: NOTIFICATION_TYPES.ERROR,
+          message: 'Manual Import Error',
+          details:
+            'The MAF file you are trying to import was not found in GDC. Please investigate and try again.',
+          timeout: false,
+          modelName,
+          onClose: () => { acknowledgeModelAndUpdateNotifications(modelName) },
+        });
+        break;
       case GENOMIC_VARIANTS_IMPORT_ERRORS.unexpected:
       default:
         appendNotification({

--- a/ui/src/components/modals/ManualImportMafModal.js
+++ b/ui/src/components/modals/ManualImportMafModal.js
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+
+import { ModalStateContext } from 'providers/ModalState';
+import { NotificationsContext } from 'components/admin/Notifications/NotificationsController';
+import NOTIFICATION_TYPES from 'components/admin/Notifications/NotificationTypes';
+import {
+  manualMafImport,
+  acknowledgeImportStatus,
+} from 'components/admin/Model/actions/GenomicVariants';
+
+import {
+  AdminModalStyle,
+  ModalWrapper,
+  Header,
+  Title,
+  CloseModal,
+  Content,
+  Footer,
+} from 'theme/adminModalStyles';
+import { ButtonPill } from 'theme/adminControlsStyles';
+import { Input } from 'theme/formComponentsStyles';
+
+const doThenClose = (next, modalState) => async () => {
+  await next();
+  return modalState.setModalState({ component: null });
+};
+
+const ManualImportMafModal = ({
+  title = 'Manual Import from GDC',
+  confirmLabel = 'Import',
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel = () => false,
+  modelName,
+  notifications,
+  appendNotification,
+  importProgress,
+  setImportProgress,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [fileId, setFileId] = useState('');
+  const [filename, setFilename] = useState('');
+
+  const confirmMafFile = async () => {
+    setLoading(true);
+    await manualMafImport(modelName, fileId, filename)
+      .then(async _ => {
+        const existingNotification = notifications.find(x => x.modelName === modelName);
+
+        if (existingNotification) {
+          existingNotification.clear();
+        }
+
+        if (onConfirm) {
+          await onConfirm();
+        }
+      })
+      .catch(error => {
+        appendNotification({
+          type: NOTIFICATION_TYPES.ERROR,
+          message: `Import Error with No Action Required: An unexpected error occured while trying to import a MAF file for ${modelName}`,
+          details: error.message,
+          timeout: false,
+          modelName,
+          onClose: () => acknowledgeImportStatus(modelName),
+        });
+      });
+  };
+
+  return (
+    <ModalStateContext.Consumer>
+      {modalState => (
+        <ModalWrapper>
+          <Header>
+            <Title>{title}</Title>
+            <CloseModal onClick={() => modalState.setModalState({ component: null })} />
+          </Header>
+          <Content>
+            <span style={{ marginBottom: '24px' }}>
+              Please specify the MAF file you would like to import for this model:
+            </span>
+            <h3>File Name:</h3>
+            <Input
+              type="text"
+              placeholder="File Name"
+              aria-label={`File Name`}
+              value={filename}
+              onChange={({ target: { value } }) => setFilename(value)}
+            />
+            <h3>File UUID:</h3>
+            <Input
+              type="text"
+              placeholder="File UUID"
+              aria-label={`File UUID`}
+              value={fileId}
+              onChange={({ target: { value } }) => setFileId(value)}
+            />
+          </Content>
+          <Footer>
+            <ButtonPill
+              primary
+              marginRight={'10px'}
+              disabled={!fileId.length || !filename.length || loading}
+              onClick={doThenClose(confirmMafFile, modalState)}
+            >
+              {confirmLabel}
+            </ButtonPill>
+            <ButtonPill secondary onClick={doThenClose(onCancel, modalState)}>
+              {cancelLabel}
+            </ButtonPill>
+          </Footer>
+        </ModalWrapper>
+      )}
+    </ModalStateContext.Consumer>
+  );
+};
+
+export default ({
+  title,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+  modelName,
+}) => Component => (
+  <NotificationsContext.Consumer>
+    {({ notifications, appendNotification, importProgress, setImportProgress }) => (
+      <ModalStateContext.Consumer>
+        {modalState =>
+          React.cloneElement(Component, {
+            onClick: () => {
+              modalState.setModalState({
+                component: (
+                  <ManualImportMafModal
+                    {...{
+                      title,
+                      confirmLabel,
+                      cancelLabel,
+                      onConfirm,
+                      onCancel,
+                      modelName,
+                      notifications,
+                      appendNotification,
+                      importProgress,
+                      setImportProgress,
+                    }}
+                  />
+                ),
+                shouldCloseOnOverlayClick: true,
+                styles: AdminModalStyle,
+              });
+            },
+          })
+        }
+      </ModalStateContext.Consumer>
+    )}
+  </NotificationsContext.Consumer>
+);

--- a/ui/src/theme/adminNavStyles.js
+++ b/ui/src/theme/adminNavStyles.js
@@ -78,7 +78,7 @@ export const DropdownItem = styled('a')`
   text-align: left;
   font-family: ${openSans};
   padding: 5px 9px;
-  font-size: 14px;
+  font-size: ${({ size }) => size || 14}px;
   font-weight: normal;
   line-height: 1.71;
   color: ${black};

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -45,6 +45,7 @@ const GENOMIC_VARIANTS_IMPORT_ERRORS = {
   badRequest: 'BAD_REQUEST',
   gdcCommunicationError: 'GDC_COMMUNICATION_ERROR',
   unexpected: 'UNEXPECTED',
+  manualImportError: 'MANUAL_IMPORT_ERROR',
 };
 
 const imgPath = '/api/data/images';


### PR DESCRIPTION
Adds a means for the content manager to manually specify a MAF file from GDC to import.

### Commits
**💄 Convert Model Research Somatic Variants Button to Dropdown (#936)**
* Convert the import Research Somatic Variants button to a dropdown to make room for the manual override

**✨ Back-end for Manual MAF Import (#936)**
* Extend `/import/:name` endpoint to accept a `fileId` and `filename` for the MAF file to import
* Add error handling for manual MAF file import errors

**✨ Front-end for Manual MAF Import (#936)**
* Add Manual MAF Import Modal
* Add front-end error handling for Manual MAF Import errors