### PR TITLE
🔖 Release 1.12.2

### DIFF
--- a/api/src/dataExport.js
+++ b/api/src/dataExport.js
@@ -19,7 +19,14 @@ const VARIANT_TYPES = {
   histopathological: 'histopathological biomarker',
   genomic: 'genomic_sequencing',
 };
-const CLINICAL_COLUMNS = ['name', 'genes', 'type', 'category'];
+const CLINICAL_COLUMNS = [
+  'name',
+  'genes',
+  'type',
+  'category',
+  'assessment_type',
+  'expression_level',
+];
 
 dataExportRouter.use(bodyParser.urlencoded({ extended: true }));
 


### PR DESCRIPTION
🐛 Add Histopathological Biomarker-specific Columns to Clinical Variants TSV
* Adds `assessment_type` and `expression_level` columns to the Clinical Variants TSV exported via the Cart or the Search Table export