### PR TITLE
🔧 Change Default Sort Column of the Catalog (#944)

### DIFF
--- a/elasticsearch/arranger_metadata/columns-state.json
+++ b/elasticsearch/arranger_metadata/columns-state.json
@@ -1,7 +1,10 @@
 {
   "type": "models",
   "keyField": "id",
-  "defaultSorted": [],
+  "defaultSorted": [{
+    "id": "gene_metadata.genomic_variant_count",
+    "desc": true
+  }],
   "columns": [
     {
       "field": "name",

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -236,7 +236,6 @@ export default ({
                         sqon={toggleExpanded(sqon, showUnexpanded)}
                         setSQON={setSQON}
                         onSortedChange={sorted => setState({ sorted })}
-                        alwaysSorted={[{ field: 'name', order: 'asc' }]}
                         customTypes={{
                           entity: props => (
                             <TableEntity


### PR DESCRIPTION
* Sort the Catalog Search table by `# of Research Somatic Variants` by default instead of `Name`

Tested to ensure that it:
- [x] does not conflict with `sessionStorage` saving of sort column
- [x] displays the sort indicator on the column header (the previous `alwaysSorted` method did not do this)

**Deployment note: this change will require the `updateEs` script to be run in order to take effect.**