### PR TITLE
🗃️ Change Mutated Genes Calculation (#946) 

### DIFF
--- a/cms/src/schemas/model.js
+++ b/cms/src/schemas/model.js
@@ -164,9 +164,17 @@ export const ModelSchema = new mongoose.Schema(
           const genomic_variant_genes = doc.genomic_variants.map(gv => gv.gene);
           const variant_genes = flatten(doc.variants.map(wrapper => wrapper.variant.genes));
           const genes = uniq([...genomic_variant_genes, ...variant_genes]);
+          // As of #946, "Mutated Genes" are Research Somatic Variants (`genomic_variants` in the codebase) and Clinical Variants only
+          const clinical_variant_genes = flatten(
+            doc.variants
+              .filter(variant => variant.variant && variant.variant.type === 'Clinical')
+              .map(wrapper => wrapper.variant.genes),
+          );
+          const mutated_genes = uniq([...genomic_variant_genes, ...clinical_variant_genes]);
 
           // Get counts of the 4 categories shown on search table
           const genes_count = genes.length;
+          const mutated_genes_count = mutated_genes.length;
           const genomic_variant_count = doc.genomic_variants.length;
           const clinical_variant_count = doc.variants.filter(
             variant => variant.variant && variant.variant.type === 'Clinical',
@@ -181,6 +189,8 @@ export const ModelSchema = new mongoose.Schema(
             genomic_variant_count,
             clinical_variant_count,
             histopathological_variant_count,
+            mutated_genes,
+            mutated_genes_count,
           };
           if (doc.gene_metadata) {
             output.filename = doc.gene_metadata.filename;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# For a quick mongo/elasticSearch local enviornment
+# For a quick mongo/elasticSearch local environment
 
 version: '3'
 services:
@@ -20,6 +20,7 @@ services:
       - discovery.type=single-node
       - cluster.name=workflow.elasticsearch
       - 'ES_JAVA_OPTS=-Xms512m -Xmx2048m'
+      - search.max_buckets=65535
   kibana:
     image: 'kibana:7.6.1'
     depends_on:

--- a/elasticsearch/arranger_metadata/aggs-state.json
+++ b/elasticsearch/arranger_metadata/aggs-state.json
@@ -263,5 +263,10 @@
     "field": "gene_metadata__genes",
     "show": false,
     "active": true
+  },
+  {
+    "field": "gene_metadata__mutated_genes",
+    "show": false,
+    "active": true
   }
 ]

--- a/elasticsearch/arranger_metadata/columns-state.json
+++ b/elasticsearch/arranger_metadata/columns-state.json
@@ -250,6 +250,16 @@
     {
       "field": "gene_metadata.genes_count",
       "accessor": "gene_metadata.genes_count",
+      "show": false,
+      "type": "genes_count",
+      "sortable": true,
+      "canChangeShow": false,
+      "query": null,
+      "jsonPath": null
+    },
+    {
+      "field": "gene_metadata.mutated_genes_count",
+      "accessor": "gene_metadata.mutated_genes_count",
       "show": true,
       "type": "genes_count",
       "sortable": true,

--- a/elasticsearch/arranger_metadata/extended.json
+++ b/elasticsearch/arranger_metadata/extended.json
@@ -823,6 +823,18 @@
     "rangeStep": 1
   },
   {
+    "field": "gene_metadata.mutated_genes_count",
+    "type": "long",
+    "displayName": "# Mutated Genes",
+    "active": false,
+    "isArray": false,
+    "primaryKey": false,
+    "quickSearchEnabled": false,
+    "unit": null,
+    "displayValues": {},
+    "rangeStep": 1
+  },
+  {
     "field": "gene_metadata.genomic_variant_count",
     "type": "long",
     "displayName": "# Research Somatic Variants",

--- a/elasticsearch/modelsIndex.json
+++ b/elasticsearch/modelsIndex.json
@@ -266,7 +266,9 @@
           "genes_count": { "type": "long" },
           "genomic_variant_count": { "type": "long" },
           "clinical_variant_count": { "type": "long" },
-          "histopathological_variant_count": { "type": "long" }
+          "histopathological_variant_count": { "type": "long" },
+          "mutated_genes": { "type": "keyword" },
+          "mutated_genes_count": { "type": "long" }
         }
       },
       "vital_status": {

--- a/ui/src/components/charts/TopVariantsChart.js
+++ b/ui/src/components/charts/TopVariantsChart.js
@@ -20,7 +20,7 @@ export default ({ sqon, setSQON }) => (
       padding: 12px 0 4px;
     `}
   >
-    <AggregationQuery sqon={sqon} field="gene_metadata__genes">
+    <AggregationQuery sqon={sqon} field="gene_metadata__mutated_genes">
       {({ state: aggState }) => {
         return (
           <Component
@@ -159,7 +159,7 @@ export default ({ sqon, setSQON }) => (
                               {
                                 op: 'in',
                                 content: {
-                                  field: 'gene_metadata.genes',
+                                  field: 'gene_metadata.mutated_genes',
                                   value: [].concat(data.data.key || []),
                                 },
                               },

--- a/ui/src/components/search/Search.js
+++ b/ui/src/components/search/Search.js
@@ -32,6 +32,7 @@ import {
   HistopathologicalBiomarkersTooltip,
   GenomicVariantsTooltip,
   ExpansionStatusTooltip,
+  MutatedGenesTooltip,
 } from 'components/tooltips';
 
 import { useExpandedUnexpanded } from 'providers/ExpandedUnexpanded';
@@ -286,7 +287,7 @@ export default ({
                             minWidth: 160,
                           },
                           age_at_sample_acquisition: { minWidth: 85 },
-                          genes_count: { minWidth: 69 },
+                          mutated_genes_count: { minWidth: 88 },
                           number: { minWidth: 88 },
                           expanded: { minWidth: 105 },
                           histo_variant_count: { minWidth: 108 },
@@ -341,6 +342,18 @@ export default ({
                                 <Row justifyContent="space-between">
                                   Available Molecular Characterizations
                                   <MolecularCharacterizationsTooltip isColumn={true} />
+                                </Row>
+                              ),
+                            },
+                          },
+                          {
+                            content: {
+                              field: 'gene_metadata.mutated_genes_count',
+                              displayName: '# Mutated Genes',
+                              Header: () => (
+                                <Row justifyContent="space-between">
+                                  # Mutated Genes
+                                  <MutatedGenesTooltip />
                                 </Row>
                               ),
                             },

--- a/ui/src/components/tooltips/index.js
+++ b/ui/src/components/tooltips/index.js
@@ -139,6 +139,20 @@ export const GenomicVariantsTooltip = ({ isFacet = false, width = null }) => (
   </InfoTooltip>
 );
 
+export const MutatedGenesTooltip = ({ isFacet = false, width = null }) => (
+  <InfoTooltip
+    ariaLabel={
+      'The # Mutated Genes is calculated as the intersection of genes associated to a mutation found in either # Research Variants or # Clinical Variants.'
+    }
+    position="bottom right"
+    iconStyle={isFacet ? resetFacetIconPositionStyle : resetIconPositionStyle}
+    width={width ? width : undefined}
+  >
+    The <b># Mutated Genes</b> is calculated as the intersection of genes associated to a mutation
+    found in either <b># Research Variants</b> or <b># Clinical Variants</b>.
+  </InfoTooltip>
+);
+
 export const ExpansionStatusTooltip = () => (
   <InfoTooltip
     ariaLabel={


### PR DESCRIPTION
## 🗃️ Change Mutated Genes Calculation (#946) 
* Exclude genes which are exclusively Histopathological Biomarkers from the `# Mutated Genes Calculation`
* Exclude genes which are exclusively Histopathological Biomarkers from the `Most Frequently Mutated Genes` chart
* Create new aggregation `gene_metadata__mutated_genes`
* Add tooltip to `# Mutated Genes` column header in Search table

##  🔧 Increase ES Max Bucket Size
* Prevent local bucket size exceptions on the TopVariantsChart by increasing the `search.max_buckets` setting on the ES instance spun up by Docker

# 🚨 **DEPLOYMENT INSTRUCTIONS** 🚨 
In order to deploy these changes, the following steps need to be run:
1) run the `updateEs` script
2) run the `republish` script
3) restart the api service