### PR TITLE
🔧 Change "Type" Display Name to "Model Type" (#965)

### DIFF
--- a/elasticsearch/arranger_metadata/extended.json
+++ b/elasticsearch/arranger_metadata/extended.json
@@ -2,7 +2,7 @@
   {
     "field": "type",
     "type": "keyword",
-    "displayName": "Type",
+    "displayName": "Model Type",
     "active": false,
     "isArray": false,
     "primaryKey": false,


### PR DESCRIPTION
* Updates the `displayName` for a model's `type` for consistency across the UI

This completes the change of the "Type" label to "Model Type" on the UI which was started in #957 

Note that it has no effect on the bulk import sheet, which still uses "Type" as its label for the field.

### 🚨 Deploy Instructions 🚨 
1. Run the `updateEs` script ```ENV={env} npm run updateEs```
2. Restart the api service