### PR TITLE
💄 Rename "Model Source" to "Case Metadata" (#964)

### DIFF
--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -245,7 +245,7 @@ const ExternalResourcesContent = ({
           </ExternalResourceLink>
           <ExternalResourceLink url={modelSourceLink}>
             <ExternalLinkIcon />
-            Model Source
+            Case Metadata
           </ExternalResourceLink>
           <ExternalResourceLink url={somaticMafLink}>
             <ExternalLinkIcon />


### PR DESCRIPTION
* Changes the label of the "Model Source" link on the Model Details page to "Case Metadata"