### PR TITLE
💄Update CMS Labelling for External Resources (#964)

### DIFF
--- a/cms/src/schemas/descriptions/model.js
+++ b/cms/src/schemas/descriptions/model.js
@@ -120,7 +120,7 @@ export const schemaArr = [
   },
   { displayName: 'Link to Distributor', accessor: 'distributor_part_number' },
   {
-    displayName: 'Model URL',
+    displayName: 'Case Metadata URL',
     accessor: 'source_model_url',
   },
   {

--- a/ui/src/components/admin/Model/ModelForm.js
+++ b/ui/src/components/admin/Model/ModelForm.js
@@ -424,7 +424,7 @@ const ModelFormTemplate = ({
 
                 <FormComponent
                   labelText={source_model_url.displayName}
-                  description="Please provide a url to GDC or EGA"
+                  description="Please provide a model url to GDC or EGA"
                 >
                   <Field
                     name={source_model_url.accessor}
@@ -437,7 +437,7 @@ const ModelFormTemplate = ({
               <FormCol>
                 <FormComponent
                   labelText={source_sequence_url.displayName}
-                  description="Please provide a url to GDC or EGA"
+                  description="Please provide a sequence url to GDC or EGA"
                 >
                   <Field
                     name={source_sequence_url.accessor}


### PR DESCRIPTION
* Change `Model URL` to `Case Metadata URL` and update descriptions for clarity