### PR TITLE
🐛 Fix Bug in Molecular Characterization Migration Script (#966)

### DIFF
--- a/cms/variant-migrations/migrations/20211014120000-update-molecular-characterizations.js
+++ b/cms/variant-migrations/migrations/20211014120000-update-molecular-characterizations.js
@@ -3,7 +3,7 @@ const targetedSeqData = require('../data/molecularCharacterizations-10-13-21-bac
 
 module.exports = {
   up(db) {
-    return db.collection('dictionary').findOneAndUpdate(
+    return db.collection('dictionary').updateMany(
       { 'fields.name': 'molecularCharacterizations' },
       {
         $set: {
@@ -14,7 +14,7 @@ module.exports = {
   },
 
   down(db) {
-    return db.collection('dictionary').findOneAndUpdate(
+    return db.collection('dictionary').updateMany(
       { 'fields.name': 'molecularCharacterizations' },
       {
         $set: {


### PR DESCRIPTION
* Use `updateMany` instead of `findOneAndUpdate` to eliminate the issue where not all `dictionary` collections would be updated to the latest Molecular Characterizations list