### PR TITLE
🐛 Remove `DNA Methylation Array` Values From Models When Migrating Down (#966)

### DIFF
--- a/cms/variant-migrations/migrations/20211021190831-remove-targeted-seq.js
+++ b/cms/variant-migrations/migrations/20211021190831-remove-targeted-seq.js
@@ -1,26 +1,38 @@
+const dnaMethylationArrayValues = ['DNA Methylation Array of parent tumor', 'DNA Methylation Array of normal', 'DNA Methylation Array of model'];
+const targetedSeqValues = ['Targeted-seq of parent tumor', 'Targeted-seq of normal', 'Targeted-seq of model'];
+
 module.exports = {
   up(db) {
     return db.collection('models').updateMany(
       {
         molecular_characterizations: {
-          $in: ['Targeted-seq of parent tumor', 'Targeted-seq of normal', 'Targeted-seq of model'],
+          $in: targetedSeqValues,
         },
       },
       {
         $pull: {
           molecular_characterizations: {
-            $in: [
-              'Targeted-seq of parent tumor',
-              'Targeted-seq of normal',
-              'Targeted-seq of model',
-            ],
+            $in: targetedSeqValues,
           },
         },
       },
     );
   },
 
-  down(db, next) {
-    next();
+  down(db) {
+    return db.collection('models').updateMany(
+      {
+        molecular_characterizations: {
+          $in: dnaMethylationArrayValues,
+        },
+      },
+      {
+        $pull: {
+          molecular_characterizations: {
+            $in: dnaMethylationArrayValues,
+          },
+        },
+      },
+    );
   },
 };


### PR DESCRIPTION
* As a safeguard, remove and `DNA Methylation Array` values from models when migrating down to a state where they may be removed from the dictionary