### PR TITLE
🐛 Fix False Positives in Auth Check

### DIFF
--- a/cms/src/helpers/authorizeUserAccess.js
+++ b/cms/src/helpers/authorizeUserAccess.js
@@ -1,17 +1,27 @@
 import User from '../schemas/user';
 import { userStatus } from './userStatus';
+
+import getLogger from '../logger';
+const logger = getLogger('helpers/authorizeUserAccess');
+
 export const USER_EMAIL = 'user_email';
 
 export const getLoggedInUser = req => ({
   user_email: req.headers[USER_EMAIL] || 'ANONYMOUS@UNKNOWN.DOMAIN',
 });
 
-const userExistsAndActive = userEmail => {
-  return User.findOne({ email: userEmail.toLowerCase() }, (err, user) => {
-    return err ? false : user && user.status === userStatus.active ? true : false;
-  });
+const userExistsAndActive = async userEmail => {
+  try {
+    const user = await User.findOne({ email: userEmail.toLowerCase() }).exec();
+    return user && user.status === userStatus.active ? true : false;
+  } catch (err) {
+    logger.error(err);
+    return false;
+  }
 };
 
-export default req => {
-  return req.headers[USER_EMAIL] && userExistsAndActive(req.headers[USER_EMAIL]);
+const isUserAuthorized = async req => {
+  return !!req.headers[USER_EMAIL] && (await userExistsAndActive(req.headers[USER_EMAIL]));
 };
+
+export default isUserAuthorized;


### PR DESCRIPTION
* Use `async/await` to ensure User lookup promise evaluates, prevent auth check from returning false positives
* Add additional logging around unauthorized requests