### PR TITLE
⚡ CMS Publishing Optimizations (#984)

### DIFF
--- a/cms/src/helpers/genomicVariants.js
+++ b/cms/src/helpers/genomicVariants.js
@@ -26,6 +26,7 @@ export const clearGenomicVariants = async name => {
       model.status === modelStatus.unpublished
         ? modelStatus.unpublished
         : modelStatus.unpublishedChanges;
+    model.variants_modified = true;
     await model.save();
     return model;
   } else {
@@ -171,6 +172,7 @@ export const addGenomicVariantsFromMaf = async (name, mafData, { filename, fileI
         ? modelStatus.unpublished
         : modelStatus.unpublishedChanges;
     model.somatic_maf_url = buildMafUrl(fileId);
+    model.variants_modified = true;
 
     if (caseId) {
       model.source_model_url = buildModelUrl(caseId);

--- a/cms/src/routes/sync-data.js
+++ b/cms/src/routes/sync-data.js
@@ -339,6 +339,7 @@ data_sync_router.get('/attach-variants/:spreadsheetId/:sheetId/:modelName', asyn
                 status: computeModelStatus(model.status, 'save'),
                 updatedBy: getLoggedInUser(req).user_email,
                 variants,
+                variants_modified: true,
               },
               {
                 upsert: true,

--- a/cms/src/schemas/model.js
+++ b/cms/src/schemas/model.js
@@ -88,6 +88,7 @@ export const ModelSchema = new mongoose.Schema(
     expanded: { type: Boolean, es_indexed: true },
     files: { type: [FilesSchema], es_indexed: true },
     variants: { type: [VariantExpression], es_indexed: true },
+    variants_modified: { type: Boolean, es_indexed: false, default: false },
     genomic_variants: { type: [GenomicVariant], es_indexed: true },
     gene_metadata: {
       type: GeneMetadata,

--- a/cms/src/services/elastic-search/publish.js
+++ b/cms/src/services/elastic-search/publish.js
@@ -14,7 +14,13 @@ const logger = getLogger('services/elastic-search/publish');
 export const publishModel = async filter => {
   await indexOneToES(filter);
   await indexMatchedModelsToES(filter);
-  await updateGeneSearchIndicies();
+  // Only update gene search indices when variants/genes have been modified
+  const modelWithVariantChanges = await Model.findOne({ ...filter, variants_modified: true });
+  if (modelWithVariantChanges) {
+    await updateGeneSearchIndicies();
+    modelWithVariantChanges.variants_modified = false;
+    await modelWithVariantChanges.save();
+  }
 };
 
 export const indexOneToES = filter => {

--- a/cms/src/validation/variant.js
+++ b/cms/src/validation/variant.js
@@ -16,7 +16,14 @@ export const modelVariantUploadSchema = object().shape({
 });
 
 export const modelVariantSchema = object().shape({
-  variant: string().required(),
+  variant: object({
+    name: string().required(),
+    type: string()
+      .oneOf(variantTypes)
+      .required(),
+    category: string().required(),
+    genes: array().required(),
+  }).required(),
   assesment_type: string().oneOf(variantAssessmentType),
   expression_level: string().oneOf(variantExpressionLevel),
 });

--- a/ui/src/components/admin/Model/ModelSingleController.js
+++ b/ui/src/components/admin/Model/ModelSingleController.js
@@ -364,27 +364,19 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
 
                   const { name } = values;
 
-                  // 1. Save model changes so we can apply matched model changes
-                  // TODO: this step is only needed when the model hasn't been saved previously.
-                  const saveModelDataResponse = await saveModel(baseUrl, values, isUpdate);
-
-                  // 2. Connect or disconnect the model to a matched set, as required.
-                  await applyMatchedModelChanges(baseUrl, values, saveModelDataResponse);
-
-                  // 3. Run the save with publish settings:
                   // Publishing will always trigger an update
                   // so we pass status in with our save
                   const modelDataResponse = await saveModel(
                     baseUrl,
                     {
-                      ...saveModelDataResponse.data,
+                      ...values,
                       files,
                       status: computeModelStatus(values.status, 'publish'),
                     },
-                    true,
+                    isUpdate,
                   );
 
-                  // 4. And now we run the initialize matched models code before setting state:
+                  // And now we run the initialize matched models code before setting state:
                   await addMatchedModelsToModelResponse(baseUrl, modelDataResponse);
                   const otherModelOptions = await getOtherModelOptions(
                     baseUrl,

--- a/ui/src/components/admin/Model/ModelSingleController.js
+++ b/ui/src/components/admin/Model/ModelSingleController.js
@@ -599,11 +599,8 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
                     ...modelData,
                     variants: modelData.variants.filter(({ _id }) => id !== _id),
                     variants_modified: true,
+                    status: computeModelStatus(modelData.status, 'save'),
                   };
-
-                  if (modelUpdate.status && modelUpdate.status !== modelStatus.unpublishedChanges) {
-                    delete modelUpdate.status;
-                  }
 
                   const modelDataResponse = await saveModel(baseUrl, modelUpdate, true);
 

--- a/ui/src/components/admin/Model/ModelSingleController.js
+++ b/ui/src/components/admin/Model/ModelSingleController.js
@@ -598,6 +598,7 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
                   let modelUpdate = {
                     ...modelData,
                     variants: modelData.variants.filter(({ _id }) => id !== _id),
+                    variants_modified: true,
                   };
 
                   if (modelUpdate.status && modelUpdate.status !== modelStatus.unpublishedChanges) {

--- a/ui/src/components/admin/helpers/modelForm.js
+++ b/ui/src/components/admin/helpers/modelForm.js
@@ -2,4 +2,4 @@
 export const isFormReadyToSave = (dirty, errors) => dirty && !('name' in errors);
 
 export const isFormReadyToPublish = (values, dirty, errors) =>
-  (values.status !== 'published' || dirty) && Object.keys(errors).length === 0;
+  values.status !== 'published' && !dirty && Object.keys(errors).length === 0;


### PR DESCRIPTION
Optimize the "Publish" step in the CMS by doing the following:
- Eliminate double network call when directly clicking "Publish" after changing a model
- Track variant changes and only update gene search indices when necessary

## Deploy Steps

As of right now, there are no additional steps required to deploy these changes.

## Commits

**⚡️ Front-end Optimizations for CMS Publishing Process (https://github.com/nci-hcmi-catalog/portal/issues/984)**
* Separate `Save` and `Publish` operations to prevent unnecessarily repeating length operations when publishing
* Require the user to click `Save` before clicking `Publish` on a model
* Change `isFormReadyToPublish` requirements to disallow publishing when form is dirty

**⚡️ Reduce Frequency of Re-indexing Gene Search Indices (https://github.com/nci-hcmi-catalog/portal/issues/984)**
* Track when a model's genes/variants have been modified with new `variants_modified` bool in model schema
* Check if variants have been modified betwen updating gene search indices