### PR TITLE
🐛 Correct Clinical Variant Validation

### DIFF
--- a/cms/src/validation/variant.js
+++ b/cms/src/validation/variant.js
@@ -16,7 +16,14 @@ export const modelVariantUploadSchema = object().shape({
 });
 
 export const modelVariantSchema = object().shape({
-  variant: string().required(),
+  variant: object({
+    name: string().required(),
+    type: string()
+      .oneOf(variantTypes)
+      .required(),
+    category: string().required(),
+    genes: array().required(),
+  }).required(),
   assesment_type: string().oneOf(variantAssessmentType),
   expression_level: string().oneOf(variantExpressionLevel),
 });

--- a/ui/src/components/admin/Model/ModelSingleController.js
+++ b/ui/src/components/admin/Model/ModelSingleController.js
@@ -599,11 +599,8 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
                     ...modelData,
                     variants: modelData.variants.filter(({ _id }) => id !== _id),
                     variants_modified: true,
+                    status: computeModelStatus(modelData.status, 'save'),
                   };
-
-                  if (modelUpdate.status && modelUpdate.status !== modelStatus.unpublishedChanges) {
-                    delete modelUpdate.status;
-                  }
 
                   const modelDataResponse = await saveModel(baseUrl, modelUpdate, true);
 


### PR DESCRIPTION
* Fixes a bug that arose after the `yup` package upgrade
* Properly define the clinical variant object structure for validation, since `yup` no longer casts plain objects to strings
* Also fixes a bug where a model's status was not updated after deleting a clinical variant