### PR TITLE
🐛 Fix False Variant Validation Errors on Bulk Publish (#1006)

### DIFF
--- a/cms/src/routes/action.js
+++ b/cms/src/routes/action.js
@@ -22,6 +22,7 @@ actionRouter.post('/publish/:name', async (req, res) => {
   Model.find({
     name,
   })
+    .populate('variants.variant')
     .then(models => runYupValidatorFailFast(validation, models))
     .then(() => publishModel({ name }))
     .then(() => res.json({ success: `${name} has been successfully published` }))

--- a/cms/src/routes/bulk.js
+++ b/cms/src/routes/bulk.js
@@ -22,6 +22,7 @@ bulkRouter.post('/publish', async (req, res) => {
   Model.find({
     _id: { $in: req.body },
   })
+    .populate('variants.variant')
     .then(models => runYupValidatorFailSlow(validation, models))
     .then(validated => {
       const validModelNames = validated


### PR DESCRIPTION
* Populate `variants.variant` before performing any model validation, ensuring variant data is in the correct format