### PR TITLE
📝 Add "HHS Vulnerability Disclosure" Link to Footer (#1008)

### DIFF
--- a/ui/src/components/Footer.js
+++ b/ui/src/components/Footer.js
@@ -37,6 +37,15 @@ const Footer = () => (
           </FooterNavItem>
           <FooterNavItem>
             <FooterLink
+              href="https://www.hhs.gov/vulnerability-disclosure-policy/index.html"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              HHS Vulnerability Disclosure
+            </FooterLink>
+          </FooterNavItem>
+          <FooterNavItem>
+            <FooterLink
               href="https://ocg.cancer.gov/programs/hcmi/frequently-asked-questions"
               target="_blank"
               rel="noopener noreferrer"

--- a/ui/src/theme/searchStyles.js
+++ b/ui/src/theme/searchStyles.js
@@ -914,7 +914,7 @@ export const Footer = styled('footer')`
   width: 100%;
   padding: 0 16px;
 
-  @media screen and (max-width: 1300px) {
+  @media screen and (max-width: 1399px) {
     min-height: 90px;
     flex-direction: column-reverse;
     justify-content: space-around;


### PR DESCRIPTION
Add new footer link and update footer styles to accommodate

### Ticket info:
For compliance with NIH IT's Vulnerability Disclosure Program, we must add a link to the HHS Vulnerability Disclosure policy page on the Footer of public facing pages.

URL: https://www.hhs.gov/vulnerability-disclosure-policy/index.html
Text: HHS Vulnerability Disclosure

From Eva:

> Alongside the vulnerability penetration testing, there is also an additional HHS requirement for the Searchable Catalog to contain a URL pointing to the “[HHS Vulnerability Disclosure](https://www.hhs.gov/vulnerability-disclosure-policy/index.html)" on the public facing page (footer). Is this something that can be incorporated into a future release?