### PR TITLE
✨ Async Publishing (#1000)

### DIFF
--- a/cms/src/index.js
+++ b/cms/src/index.js
@@ -21,6 +21,7 @@ import {
   matchedModelsRouter as matchedModelsActionsRouter,
   templatesRouter,
   variantsRouter,
+  publishRouter,
 } from './routes';
 import {
   preUpdate,
@@ -121,6 +122,7 @@ app.use('/api/v1/action', actionRouter);
 app.use('/api/v1/templates', templatesRouter);
 app.use('/api/v1/genomic-variants', variantsRouter);
 app.use('/api/v1/matches', matchedModelsActionsRouter);
+app.use('/api/v1/publish', publishRouter);
 app.use(matchedModelsRestifyRouter);
 app.use(modelRouter);
 app.use(userRouter);

--- a/cms/src/routes/index.js
+++ b/cms/src/routes/index.js
@@ -6,3 +6,4 @@ export { default as templatesRouter } from './templates';
 export { default as matchedModelsRouter } from './matchedModels';
 export { default as healthRouter } from './health';
 export { default as variantsRouter } from './genomicVariants';
+export { default as publishRouter } from './publish';

--- a/cms/src/routes/publish.js
+++ b/cms/src/routes/publish.js
@@ -21,7 +21,9 @@ const publishRouter = express.Router();
     - Fetch data for all specified models
     - Validate data for specified models
     - Add valid models to queue and start queue, add errors to error queue
-    Input: list of model names in request body
+    Input:
+      string[]: models - list of model names in request body,
+      boolean: ids - (optional) flag specifying whether list is IDs (true) or model names (false)
     Output: success if models were added to queues and queue was started without issue, error otherwise
 
 3. Publish (Single Model)
@@ -74,7 +76,7 @@ publishRouter.get('/status', async (req, res) => {
 });
 
 publishRouter.post('/bulk', async (req, res) => {
-  const { models } = req.body;
+  const { models, ids = false } = req.body;
 
   if (!Array.isArray(models) || models.length < 1) {
     logger.error(
@@ -93,7 +95,7 @@ publishRouter.post('/bulk', async (req, res) => {
   try {
     logger.debug(`Starting bulk publish for models: ${models}`);
 
-    const result = await Publisher.queueBulkPublish(models);
+    const result = await Publisher.queueBulkPublish(models, ids);
 
     if (result.error) {
       return res.status(400).json({ success: false, error: result.error });
@@ -182,7 +184,7 @@ publishRouter.post('/acknowledge/:name', async (req, res) => {
 
 publishRouter.post('/stop/all', async (req, res) => {
   try {
-    logger.debug(`Stopping import for all queued models`);
+    logger.debug(`Stopping publish for all queued models`);
 
     const stopped = await Publisher.stopBulkPublish();
 

--- a/cms/src/routes/publish.js
+++ b/cms/src/routes/publish.js
@@ -51,28 +51,6 @@ const publishRouter = express.Router();
     Output: success if models were stopped, and data for stopped models
 */
 
-publishRouter.post('/:name', async (req, res) => {
-  const { name } = req.params;
-
-  try {
-    logger.debug(`Starting publish for model ${name}`);
-
-    const result = await Publisher.queueIndividualPublish(name);
-
-    if (result.error) {
-      return res.status(400).json({ success: false, error: result.error });
-    }
-
-    return res.status(200).json({ success: true, startTime: result.startTime });
-  } catch (error) {
-    logger.error(error, `Error occurred while queueing publish task for model ${name}`);
-    res.status(500).json({
-      success: false,
-      error: error,
-    });
-  }
-});
-
 publishRouter.post('/bulk', async (req, res) => {
   const { models } = req.body;
 
@@ -109,6 +87,28 @@ publishRouter.post('/bulk', async (req, res) => {
   }
 });
 
+publishRouter.post('/:name', async (req, res) => {
+  const { name } = req.params;
+
+  try {
+    logger.debug(`Starting publish for model ${name}`);
+
+    const result = await Publisher.queueIndividualPublish(name);
+
+    if (result.error) {
+      return res.status(400).json({ success: false, error: result.error });
+    }
+
+    return res.status(200).json({ success: true, startTime: result.startTime });
+  } catch (error) {
+    logger.error(error, `Error occurred while queueing publish task for model ${name}`);
+    res.status(500).json({
+      success: false,
+      error: error,
+    });
+  }
+});
+
 publishRouter.get('/status', async (req, res) => {
   try {
     logger.debug(`Fetching Publisher status...`);
@@ -118,23 +118,6 @@ publishRouter.get('/status', async (req, res) => {
     res.status(200).json({ ...status });
   } catch (error) {
     logger.error(error, `Error occurred during Publisher status fetch`);
-    res.status(500).json({
-      success: false,
-      error: error,
-    });
-  }
-});
-
-publishRouter.post('/acknowledge/:name', async (req, res) => {
-  const { name } = req.params;
-  try {
-    logger.debug(`Acknowledging publish status for model ${name}`);
-
-    const acknowledged = Publisher.acknowledge(name);
-
-    res.status(200).json({ acknowledged, success: true });
-  } catch (error) {
-    logger.error(error, `Error occurred during publish status acknowledgement for model ${name}`);
     res.status(500).json({
       success: false,
       error: error,
@@ -174,16 +157,16 @@ publishRouter.post('/acknowledge/bulk', async (req, res) => {
   }
 });
 
-publishRouter.post('/stop/:name', async (req, res) => {
+publishRouter.post('/acknowledge/:name', async (req, res) => {
   const { name } = req.params;
   try {
-    logger.debug(`Stopping publish for model ${name}`);
+    logger.debug(`Acknowledging publish status for model ${name}`);
 
-    const stopped = await Publisher.stopPublish(name);
+    const acknowledged = Publisher.acknowledge(name);
 
-    res.status(200).json({ stopped, success: true });
+    res.status(200).json({ acknowledged, success: true });
   } catch (error) {
-    logger.error(error, `Error occurred during publish stop for model ${name}`);
+    logger.error(error, `Error occurred during publish status acknowledgement for model ${name}`);
     res.status(500).json({
       success: false,
       error: error,
@@ -200,6 +183,23 @@ publishRouter.post('/stop/all', async (req, res) => {
     res.status(200).json({ stopped, success: true });
   } catch (error) {
     logger.error(error, `Error occurred during bulk publish stop`);
+    res.status(500).json({
+      success: false,
+      error: error,
+    });
+  }
+});
+
+publishRouter.post('/stop/:name', async (req, res) => {
+  const { name } = req.params;
+  try {
+    logger.debug(`Stopping publish for model ${name}`);
+
+    const stopped = await Publisher.stopPublish(name);
+
+    res.status(200).json({ stopped, success: true });
+  } catch (error) {
+    logger.error(error, `Error occurred during publish stop for model ${name}`);
     res.status(500).json({
       success: false,
       error: error,

--- a/cms/src/routes/publish.js
+++ b/cms/src/routes/publish.js
@@ -1,0 +1,210 @@
+import express from 'express';
+import Model from '../schemas/model';
+import Publisher from '../services/publish/Publisher';
+import { PUBLISH_ERRORS } from '../services/publish/constants';
+
+import getLogger from '../logger';
+
+const logger = getLogger('routes/publish');
+
+const publishRouter = express.Router();
+
+/* Description of Endpoints
+
+1. Publish (Single Model)
+    - Fetch model data
+    - Validate model
+    - Add publish to queue if possible and start the queue, or return an error
+    Input: model name
+    Output: success if valid model and added to queue, error otherwise
+
+2. Publish (Bulk)
+    - Fetch data for all specified models
+    - Validate data for specified models
+    - Add valid models to queue and start queue, add errors to error queue
+    Input: list of model names
+    Output: success if models were added to queues and queue was started without issue, error otherwise
+
+3. Get Publish Queue Status
+    - Request lists of async publish operations currently running
+    Input: none
+    Output: object with lists of publish jobs in various states (queue, failed, success, stopped)
+
+4. Acknowledge Publish Activity Has Been Seen (Single Model)
+    - Acknowledges that the user has seen the publish activity (success, error, stopped) for a model
+    Input: model name
+    Output: success if model was found in queue and acknowledged, and data for acknowledged model
+
+5. Acknowledge Publish Activity Has Been Seen (Bulk)
+    - Acknowledges that the user has seen the publish activity (success, error, stopped) for a list of models
+    Input: list of model names
+    Output: success if models were found in queue and acknowledged, and data for acknowledged models
+
+6. Stop Publish (Single Model)
+    - Stops a given model from being published if it has not already been processed
+    Input: model name
+    Output: success if model was found in queue and stopped, and data for stopped model
+
+7. Stop Publish (Bulk)
+    - Stops all waiting models from being published
+    Input: none
+    Output: success if models were stopped, and data for stopped models
+*/
+
+publishRouter.post('/:name', async (req, res) => {
+  const { name } = req.params;
+
+  try {
+    logger.debug(`Starting publish for model ${name}`);
+
+    const result = await Publisher.queueIndividualPublish(name);
+
+    if (result.error) {
+      return res.status(400).json({ success: false, error: result.error });
+    }
+
+    return res.status(200).json({ success: true, startTime: result.startTime });
+  } catch (error) {
+    logger.error(error, `Error occurred while queueing publish task for model ${name}`);
+    res.status(500).json({
+      success: false,
+      error: error,
+    });
+  }
+});
+
+publishRouter.post('/bulk', async (req, res) => {
+  const { models } = req.body;
+
+  if (!Array.isArray(models) || models.length < 1) {
+    logger.error(
+      'Bulk publish failed due to a bad request. `models` must be an array of model names.',
+    );
+    return res.status(400).json({
+      success: false,
+      error: {
+        code: PUBLISH_ERRORS.badRequest,
+        message:
+          'Bulk publish failed due to a bad request. `models` must be an array of model names.',
+      },
+    });
+  }
+
+  try {
+    logger.debug(`Starting bulk publish for models: ${models}`);
+
+    const result = await Publisher.queueBulkPublish(models);
+
+    if (result.error) {
+      return res.status(400).json({ success: false, error: result.error });
+    }
+
+    return res.status(200).json({ success: true, startTime: result.startTime });
+  } catch (error) {
+    logger.error(error, `Error occurred during bulk publish`);
+    res.status(500).json({
+      success: false,
+      error: error,
+    });
+  }
+});
+
+publishRouter.get('/status', async (req, res) => {
+  try {
+    logger.debug(`Fetching Publisher status...`);
+
+    const status = Publisher.getStatus();
+
+    res.status(200).json({ ...status });
+  } catch (error) {
+    logger.error(error, `Error occurred during Publisher status fetch`);
+    res.status(500).json({
+      success: false,
+      error: error,
+    });
+  }
+});
+
+publishRouter.post('/acknowledge/:name', async (req, res) => {
+  const { name } = req.params;
+  try {
+    logger.debug(`Acknowledging publish status for model ${name}`);
+
+    const acknowledged = Publisher.acknowledge(name);
+
+    res.status(200).json({ acknowledged, success: true });
+  } catch (error) {
+    logger.error(error, `Error occurred during publish status acknowledgement for model ${name}`);
+    res.status(500).json({
+      success: false,
+      error: error,
+    });
+  }
+});
+
+publishRouter.post('/acknowledge/bulk', async (req, res) => {
+  const { models } = req.body;
+
+  if (!Array.isArray(models) || models.length < 1) {
+    logger.error(
+      'Bulk acknowledge failed due to a bad request. `models` must be an array of model names.',
+    );
+    return res.status(400).json({
+      success: false,
+      error: {
+        code: PUBLISH_ERRORS.badRequest,
+        message:
+          'Bulk acknowledge failed due to a bad request. `models` must be an array of model names.',
+      },
+    });
+  }
+
+  try {
+    logger.debug(`Starting bulk acknowledge for models: ${models}`);
+
+    const acknowledged = Publisher.acknowledgeBulk(models);
+
+    res.status(200).json({ acknowledged, success: true });
+  } catch (error) {
+    logger.error(error, `Error occurred during bulk model acknowledge`);
+    res.status(500).json({
+      success: false,
+      error: error,
+    });
+  }
+});
+
+publishRouter.post('/stop/:name', async (req, res) => {
+  const { name } = req.params;
+  try {
+    logger.debug(`Stopping publish for model ${name}`);
+
+    const stopped = await Publisher.stopPublish(name);
+
+    res.status(200).json({ stopped, success: true });
+  } catch (error) {
+    logger.error(error, `Error occurred during publish stop for model ${name}`);
+    res.status(500).json({
+      success: false,
+      error: error,
+    });
+  }
+});
+
+publishRouter.post('/stop/all', async (req, res) => {
+  try {
+    logger.debug(`Stopping import for all queued models`);
+
+    const stopped = await Publisher.stopBulkPublish();
+
+    res.status(200).json({ stopped, success: true });
+  } catch (error) {
+    logger.error(error, `Error occurred during bulk publish stop`);
+    res.status(500).json({
+      success: false,
+      error: error,
+    });
+  }
+});
+
+export default publishRouter;

--- a/cms/src/services/publish/Publisher.js
+++ b/cms/src/services/publish/Publisher.js
@@ -1,0 +1,448 @@
+import Model from '../../schemas/model';
+import getPublishValidation from '../../validation/model';
+import { runYupValidatorFailSlow } from '../../helpers';
+import { PUBLISH_ERRORS } from './constants';
+import { getPublishErrorMessage } from './helpers';
+import { publishModel } from '../elastic-search/publish';
+import getLogger from '../../logger';
+
+const logger = getLogger('services/publish/Publisher');
+
+const PublishStatus = {
+  active: 'ACTIVE',
+  complete: 'COMPLETE',
+  error: 'ERROR',
+  stopped: 'STOPPED',
+  waiting: 'WAITING',
+};
+
+const PublishTypes = {
+  bulk: 'BULK',
+  individual: 'INDIVIDUAL',
+};
+
+const PublishTask = ({
+  modelName = null,
+  error = null,
+  status = PublishStatus.waiting,
+  publishType = PublishTypes.individual,
+}) => {
+  const createdAt = Date.now();
+  let acknowledged = false;
+  let startTime = null;
+  let stopTime = null;
+
+  const start = async () => {
+    status = PublishStatus.active;
+    startTime = Date.now();
+    logger.info({ startTime, modelName }, 'Publish started.');
+    return await performPublish();
+  };
+
+  const stop = () => {
+    status = PublishStatus.stopped;
+    stopTime = Date.now();
+    logger.info({ startTime, stopTime, modelName }, 'Publish stopped.');
+  };
+
+  const complete = () => {
+    status = PublishStatus.complete;
+    stopTime = Date.now();
+    logger.info({ startTime, stopTime, modelName }, 'Publish complete.');
+  };
+
+  const errorStop = errorData => {
+    status = PublishStatus.error;
+    error = errorData;
+    stopTime = Date.now();
+    logger.info({ startTime, stopTime, modelName, error }, 'Publish stopped due to error.');
+  };
+
+  const acknowledge = () => {
+    acknowledged = true;
+  };
+
+  const getData = () => ({
+    acknowledged,
+    createdAt,
+    error,
+    publishType,
+    modelName,
+    status,
+    startTime,
+    stopTime,
+  });
+
+  const performPublish = async () => {
+    if (!modelName) {
+      errorStop({
+        code: PUBLISH_ERRORS.badRequest,
+        message: `Unable to perform publish without a modelName.`,
+      });
+      return;
+    }
+
+    try {
+      // early return if PublishStatus changes mid-publish (due to manual stop or error)
+      if (status !== PublishStatus.active) {
+        return;
+      }
+
+      logger.debug({ time: Date.now(), startTime, modelName }, 'Beginning ES Publish...');
+
+      await publishModel({ name: modelName }).then(() => {
+        logger.debug({ time: Date.now(), startTime, modelName }, 'Completed Publish');
+        complete();
+      });
+    } catch (error) {
+      logger.error(error, 'Unexpected Publish Error');
+      errorStop({ code: PUBLISH_ERRORS.unexpected, message: error.message, error });
+    }
+  };
+
+  return {
+    acknowledge,
+    error,
+    errorStop,
+    getData,
+    modelName,
+    start,
+    stop,
+  };
+};
+
+const Publisher = (function() {
+  let queue = [];
+  let failed = [];
+  let stopped = [];
+  let success = [];
+  let running = false;
+
+  const cleanLists = () => {
+    failed = failed.filter(i => i && i.getData && !i.getData().acknowledged);
+    stopped = stopped.filter(i => i && i.getData && !i.getData().acknowledged);
+    success = success.filter(i => i && i.getData && !i.getData().acknowledged);
+
+    // queue should never have anything acknowledged (should move to failed/stopped/success)
+    // clearing just in case
+    queue = queue.filter(i => i && i.getData && !i.getData().acknowledged);
+  };
+
+  const emptyQueue = () => {
+    queue = [];
+  };
+
+  const queueIndividualPublish = async modelName => {
+    // Check for Model existence:
+    const model = await Model.findOne({ name: modelName });
+    if (!model) {
+      return {
+        error: {
+          code: PUBLISH_ERRORS.noMatchingModel,
+          message: getPublishErrorMessage(PUBLISH_ERRORS.noMatchingModel, modelName),
+        },
+      };
+    }
+
+    // Remove duplicate publish tasks
+    stopPublish(modelName);
+    acknowledge(modelName);
+
+    try {
+      const validation = await getPublishValidation();
+      let newPublishTask;
+
+      // Validate model before adding to queue
+      Model.find({
+        name: modelName,
+      })
+        .populate('variants.variant')
+        .then(model => runYupValidatorFailSlow(validation, model))
+        .then(results => {
+          if (results[0].success) {
+            // Create new publish task
+            newPublishTask = PublishTask({
+              modelName,
+            });
+
+            // Add to queue
+            queue.push(newPublishTask);
+          } else {
+            // Validation failed, create task with validation error
+            newPublishTask = PublishTask({
+              modelName: results[0].name,
+              status: PublishStatus.error,
+              error: {
+                code: PUBLISH_ERRORS.validationError,
+                // TODO: investigate validationError structure
+                message: results[0].details,
+              },
+            });
+
+            // Add to failed
+            failed.push(newPublishTask);
+          }
+        });
+
+      // Start queue
+      if (!running) {
+        start();
+      }
+
+      return { success: true, startTime: Date.now() };
+    } catch (error) {
+      logger.error(error, 'Error occurred while adding publish task to queue.');
+      return {
+        error: {
+          code: PUBLISH_ERRORS.unexpected,
+          message: error.message,
+          error,
+        },
+      };
+    }
+  };
+
+  const queueBulkPublish = async models => {
+    if (!Array.isArray(models) || models.length < 1) {
+      logger.error(
+        'queueBulkPublish failed due to bad input. `models` must be an array of model names.',
+      );
+      return {
+        error: {
+          code: PUBLISH_ERRORS.badRequest,
+          message:
+            'Unable to queue bulk import due to bad input. `models` must be an array of model names.',
+        },
+      };
+    }
+
+    // Remove duplicate imports
+    stopBulkPublish(models);
+    acknowledgeBulk(models);
+
+    // Filter out models that don't exist within HCMI db
+    let noMatchingModel = [];
+    models = models.filter(async modelName => {
+      let match = await Model.findOne({ name: modelName });
+
+      if (!match) {
+        noMatchingModel.push(modelName);
+      }
+
+      return match;
+    });
+
+    const validation = await getPublishValidation();
+    let validationErrors;
+
+    // Validate models for publishing
+    const validModels = Model.find({
+      name: { $in: models },
+    })
+      .populate('variants.variant')
+      .then(models => runYupValidatorFailSlow(validation, models))
+      .then(validated => {
+        const validModelNames = validated
+          .filter(({ success }) => success)
+          .map(({ result: { name } }) => name);
+
+        // Put any validation errors into higher scope for return
+        validationErrors = validated.filter(({ success }) => !success).map(({ errors }) => errors);
+
+        return validModelNames;
+      });
+
+    // Add models which weren't found in HCMI db or failed validation
+    failed = [
+      ...failed,
+      ...noMatchingModel.map(modelName =>
+        PublishTask({
+          modelName,
+          status: PublishStatus.error,
+          error: {
+            code: PUBLISH_ERRORS.noMatchingModel,
+            message: getPublishErrorMessage(PUBLISH_ERRORS.noMatchingModel, modelName),
+          },
+          publishType: PublishTypes.bulk,
+        }),
+      ),
+      ...validationErrors.map(validationError =>
+        PublishTask({
+          modelName: validationError.name,
+          status: PublishStatus.error,
+          error: {
+            code: PUBLISH_ERRORS.validationError,
+            // TODO: investigate validationError structure
+            message: validationError.details,
+          },
+          publishType: PublishTypes.bulk,
+        }),
+      ),
+    ];
+
+    // Queue publish tasks for remaining models which were found
+    queue = [
+      ...queue,
+      ...validModels.map(modelName => {
+        return PublishTask({
+          modelName,
+          publishType: PublishTypes.bulk,
+        });
+      }),
+    ];
+
+    logger.debug({ time: Date.now(), models, noMatchingModel }, 'Beginning bulk publish queue...');
+
+    // Start queue
+    if (!running) {
+      start();
+    }
+
+    return { success: true, startTime: Date.now() };
+  };
+
+  const stopPublish = async modelName => {
+    // In case we get into an invalid state with multiple publish tasks for a given model,
+    //   we'll use filter to get the whole list of them.
+    const targets = queue.filter(i => i && i.modelName === modelName);
+    if (targets.length) {
+      targets.forEach(target => target.stop());
+      stopped = [...stopped, ...targets];
+      queue = queue.filter(i => i && i.modelName !== modelName);
+    }
+
+    cleanLists();
+
+    return targets.map(target => target.getData());
+  };
+
+  const stopBulkPublish = async (modelNames = []) => {
+    pause();
+
+    let targets = [];
+    // if modelNames are provided, only stop those publish tasks
+    // otherwise, stop all queued publish tasks
+    if (modelNames.length) {
+      modelNames.forEach(modelName => {
+        targets = [...targets, ...queue.filter(i => i && i.modelName === modelName)];
+      });
+    } else {
+      targets = queue;
+    }
+
+    if (targets.length) {
+      targets.forEach(target => target.stop());
+      stopped = [...stopped, ...targets];
+      emptyQueue();
+    }
+
+    cleanLists();
+
+    return targets.map(target => target.getData());
+  };
+
+  const getStatus = () => {
+    cleanLists();
+    return {
+      queue: queue.map(i => i.getData()),
+      failed: failed.map(i => i.getData()),
+      stopped: stopped.map(i => i.getData()),
+      success: success.map(i => i.getData()),
+      running,
+    };
+  };
+
+  const acknowledge = modelName => {
+    const targets = [
+      ...failed.filter(i => i && i.modelName === modelName),
+      ...stopped.filter(i => i && i.modelName === modelName),
+      ...success.filter(i => i && i.modelName === modelName),
+    ];
+    if (targets.length) {
+      targets.forEach(target => target.acknowledge());
+    }
+
+    cleanLists();
+
+    return targets.map(target => target.getData());
+  };
+
+  const acknowledgeBulk = modelNames => {
+    let targets = [];
+
+    modelNames.forEach(modelName => {
+      targets = [
+        ...targets,
+        ...failed.filter(i => i && i.modelName === modelName),
+        ...stopped.filter(i => i && i.modelName === modelName),
+        ...success.filter(i => i && i.modelName === modelName),
+      ];
+    });
+
+    if (targets.length) {
+      targets.forEach(target => target.acknowledge());
+    }
+
+    cleanLists();
+
+    return targets.map(target => target.getData());
+  };
+
+  const pause = () => {
+    running = false;
+  };
+
+  const start = () => {
+    running = true;
+    run();
+  };
+
+  const run = async () => {
+    if (queue.length > 0) {
+      // Grab first item in queue and perform publish task
+      const nextPublish = queue[0];
+      await nextPublish.start();
+      // Move from queue to appropriate list based on success/failure of publish
+      switch (nextPublish.getData().status) {
+        case PublishStatus.complete:
+          success.push(queue.shift());
+          break;
+        case PublishStatus.error:
+          failed.push(queue.shift());
+          break;
+        case PublishStatus.stopped:
+          stopped.push(queue.shift());
+          break;
+        default:
+          // Only get here if something went wrong and status wasn't updated
+          // NOTE: upon testing, this did not ever happen...
+          // Shouldn't be possible, just covering all bases
+          logger.error(
+            'Failed to update status following publish for model:',
+            nextPublish.getData(),
+          );
+          // Remove from queue anyway to prevent infinite loop
+          queue.shift();
+          break;
+      }
+    }
+
+    if (running && queue.length > 0) {
+      run();
+    } else {
+      pause();
+    }
+  };
+
+  return {
+    acknowledge,
+    acknowledgeBulk,
+    getStatus,
+    queueIndividualPublish,
+    queueBulkPublish,
+    stopPublish,
+    stopBulkPublish,
+  };
+})();
+
+export default Publisher;

--- a/cms/src/services/publish/Publisher.js
+++ b/cms/src/services/publish/Publisher.js
@@ -83,7 +83,7 @@ const PublishTask = ({
     }
 
     try {
-      // early return if PublishStatus changes mid-publish (due to manual stop or error)
+      // early return if status changed mid-publish (due to manual stop)
       if (status !== PublishStatus.active) {
         return;
       }
@@ -153,7 +153,7 @@ const Publisher = (function() {
       let newPublishTask;
 
       // Validate model before adding to queue
-      Model.find({
+      await Model.find({
         name: modelName,
       })
         .populate('variants.variant')
@@ -236,7 +236,7 @@ const Publisher = (function() {
     let validationErrors;
 
     // Validate models for publishing
-    const validModels = Model.find({
+    const validModels = await Model.find({
       name: { $in: models },
     })
       .populate('variants.variant')

--- a/cms/src/services/publish/constants.js
+++ b/cms/src/services/publish/constants.js
@@ -1,0 +1,10 @@
+export const PUBLISH_ERRORS = {
+  // No local model matching input modelName
+  noMatchingModel: 'NO_MATCHING_MODEL',
+  // Malformed input for request
+  badRequest: 'BAD_REQUEST',
+  // Validation failed for model
+  validationError: 'VALIDATION_ERROR',
+  // Unexpected error
+  unexpected: 'UNEXPECTED',
+};

--- a/cms/src/services/publish/helpers.js
+++ b/cms/src/services/publish/helpers.js
@@ -3,10 +3,10 @@ import { PUBLISH_ERRORS } from './constants';
 export const getPublishErrorMessage = (publishError, modelName) => {
   switch (publishError) {
     case PUBLISH_ERRORS.noMatchingModel:
-      return `No local model found with matching name ${modelName}.`;
+      return `Model ${modelName} was not found in the HCMI database.`;
     case PUBLISH_ERRORS.badRequest:
-      return `Unable to perform publish without modelName.`;
+      return `There was a problem with the data in your publish request. Please ensure that all required fields are present and try again.`;
     default:
-      return `An unexpected error occured during publish for ${modelName}.`;
+      return `An unexpected error occured during publish for model ${modelName}.`;
   }
 };

--- a/cms/src/services/publish/helpers.js
+++ b/cms/src/services/publish/helpers.js
@@ -1,0 +1,12 @@
+import { PUBLISH_ERRORS } from './constants';
+
+export const getPublishErrorMessage = (publishError, modelName) => {
+  switch (publishError) {
+    case PUBLISH_ERRORS.noMatchingModel:
+      return `No local model found with matching name ${modelName}.`;
+    case PUBLISH_ERRORS.badRequest:
+      return `Unable to perform publish without modelName.`;
+    default:
+      return `An unexpected error occured during publish for ${modelName}.`;
+  }
+};

--- a/ui/src/components/admin/Model/ModelSingleController.js
+++ b/ui/src/components/admin/Model/ModelSingleController.js
@@ -18,6 +18,7 @@ import {
   getMatchedModelSet,
   connectModelToSet,
   disconnectModelFromSets,
+  singleAction,
 } from '../helpers';
 import { getDictionary } from '../helpers/dictionary';
 
@@ -354,71 +355,61 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
                   },
                 }));
 
-                try {
-                  const {
-                    form: { isUpdate },
-                    data: {
-                      response: { files = [] },
-                    },
-                  } = state;
+                const { name } = values;
 
-                  const { name } = values;
+                singleAction('publish', name)
+                  .then(async () => {
+                    // Fetch full model data in order to update model status
+                    const modelDataResponse = await getModel(baseUrl, name);
+                    // Prepare matched model details if necessary
+                    await addMatchedModelsToModelResponse(baseUrl, modelDataResponse);
+                    const otherModelOptions = await getOtherModelOptions(
+                      baseUrl,
+                      modelDataResponse.data.name,
+                    );
 
-                  // Publishing will always trigger an update
-                  // so we pass status in with our save
-                  const modelDataResponse = await saveModel(
-                    baseUrl,
-                    {
-                      ...values,
-                      files,
-                      status: computeModelStatus(values.status, 'publish'),
-                    },
-                    isUpdate,
-                  );
+                    await setState(state => ({
+                      form: {
+                        ...state.form,
+                        isReadyToPublish: false,
+                        isReadyToSave: false,
+                      },
+                      data: {
+                        ...state.data,
+                        isLoading: false,
+                        response: modelDataResponse.data,
+                      },
+                      otherModelOptions,
+                    }));
 
-                  // And now we run the initialize matched models code before setting state:
-                  await addMatchedModelsToModelResponse(baseUrl, modelDataResponse);
-                  const otherModelOptions = await getOtherModelOptions(
-                    baseUrl,
-                    modelDataResponse.data.name,
-                  );
-                  await setState(state => ({
-                    form: {
-                      ...state.form,
-                      isReadyToPublish: false,
-                      isReadyToSave: false,
-                    },
-                    data: {
-                      ...state.data,
-                      isLoading: false,
-                      response: modelDataResponse.data,
-                    },
-                    otherModelOptions,
-                  }));
+                    await appendNotification({
+                      type: NOTIFICATION_TYPES.SUCCESS,
+                      message: 'Publish Successful!',
+                      details: `${name} has been successfully published. View it live here: `,
+                      link: `/model/${name}`,
+                      linkText: name,
+                    });
+                  })
+                  .catch(async err => {
+                    const errorText = extractErrorText(err);
 
-                  await appendNotification({
-                    type: NOTIFICATION_TYPES.SUCCESS,
-                    message: 'Publish Successful!',
-                    details: `${name} has been successfully published. View it live here: `,
-                    link: `/model/${modelDataResponse.data.name}`,
-                    linkText: modelDataResponse.data.name,
+                    await setState(state => ({
+                      data: {
+                        ...state.data,
+                        isLoading: false,
+                        error: err,
+                      },
+                    }));
+
+                    await appendNotification({
+                      type: NOTIFICATION_TYPES.ERROR,
+                      message: 'Publish Error.',
+                      details:
+                        errorText ||
+                        err.msg ||
+                        get(err, 'response.data.message', 'Unknown error has occurred.'),
+                    });
                   });
-                } catch (err) {
-                  await setState(state => ({
-                    data: {
-                      ...state.data,
-                      isLoading: false,
-                      error: err,
-                    },
-                  }));
-
-                  await appendNotification({
-                    type: NOTIFICATION_TYPES.ERROR,
-                    message: 'Publish Error.',
-                    details:
-                      err.msg || get(err, 'response.data.message', 'Unknown error has occurred.'),
-                  });
-                }
               },
               unpublishModel: async values => {
                 const { name } = values;

--- a/ui/src/components/admin/Model/ModelSingleController.js
+++ b/ui/src/components/admin/Model/ModelSingleController.js
@@ -754,6 +754,49 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
                   }
                 }
               },
+              fetchModelData: async modelName => {
+                if (modelName) {
+                  setState(state => ({
+                    data: {
+                      ...state.data,
+                      isLoading: true,
+                    },
+                  }));
+
+                  try {
+                    // Fetch full model data in order to update model status
+                    const modelDataResponse = await getModel(baseUrl, modelName);
+                    // Prepare matched model details if necessary
+                    await addMatchedModelsToModelResponse(baseUrl, modelDataResponse);
+                    const otherModelOptions = await getOtherModelOptions(
+                      baseUrl,
+                      modelDataResponse.data.name,
+                    );
+
+                    await setState(state => ({
+                      form: {
+                        ...state.form,
+                        isReadyToPublish: false,
+                        isReadyToSave: false,
+                      },
+                      data: {
+                        ...state.data,
+                        isLoading: false,
+                        response: modelDataResponse.data,
+                      },
+                      otherModelOptions,
+                    }));
+                  } catch (err) {
+                    setState(state => ({
+                      data: {
+                        ...state.data,
+                        isLoading: false,
+                        error: err,
+                      },
+                    }));
+                  }
+                }
+              },
             }}
             {...props}
           >

--- a/ui/src/components/admin/Model/ModelSingleHeader.js
+++ b/ui/src/components/admin/Model/ModelSingleHeader.js
@@ -96,7 +96,7 @@ const ModelSingleHeader = ({ modelName }) => {
   const { isPublishingModel, publishRunning } = usePublishNotifications();
   const publishState = useRef();
 
-  // Fetch data after publish completes
+  // refresh model data after publish completes (get updated publish status)
   useEffect(() => {
     const refreshModelData = async () => await fetchModelData(modelName);
 

--- a/ui/src/components/admin/Model/ModelSingleHeader.js
+++ b/ui/src/components/admin/Model/ModelSingleHeader.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import Popup from 'reactjs-popup';
 import { css } from '@emotion/react';
 
 import { ModelSingleContext } from './ModelSingleController';
 import { manageModelsUrlBase } from '../AdminNav';
+import { NotificationsContext, usePublishNotifications } from 'components/admin/Notifications';
 
 import { SaveModel, PublishModel, ActionsMenu } from './actions';
 
@@ -13,7 +14,7 @@ import MoreOptionsIcon from 'icons/MoreOptionsIcon';
 import { AdminHeader, AdminHeaderBlock } from 'theme/adminStyles';
 import { ModelHeaderH1, ModelHeaderBackLink } from 'theme/adminModelStyles';
 import { ButtonPill } from 'theme/adminControlsStyles';
-import { modelStatusPill } from '../ModelsManager/ModelColumns';
+import { ModelStatusPillWithPublish } from '../ModelsManager/ModelColumns';
 import ExternalLinkIcon from 'icons/ExternalLinkIcon';
 import { modelStatus } from '@hcmi-portal/cms/src/helpers/modelStatus';
 
@@ -84,59 +85,80 @@ const modelMoreOptions = (data = null) =>
     </Popup>
   );
 
-const ModelSingleHeader = ({ modelName }) => (
-  <ModelSingleContext.Consumer>
-    {({
-      state: {
-        data: { response, error },
-      },
-    }) => (
-      <>
-        <AdminHeader>
-          <AdminHeaderBlock
-            css={css`
-              position: relative;
-            `}
-          >
-            {headerText(modelName, error)}
-            {response.status && modelStatusPill(response)}
-            <ModelHeaderBackLink
-              to={manageModelsUrlBase}
+const ModelSingleHeader = ({ modelName }) => {
+  const {
+    state: {
+      data: { response, error },
+    },
+    fetchModelData,
+  } = useContext(ModelSingleContext);
+  const { publishProgress } = useContext(NotificationsContext);
+  const { isPublishingModel, publishRunning } = usePublishNotifications();
+  const publishState = useRef();
+
+  // Fetch data after publish completes
+  useEffect(() => {
+    const refreshModelData = async () => await fetchModelData(modelName);
+
+    if (modelName && isPublishingModel(modelName) && (!publishState || !publishState.current)) {
+      publishState.current = 'publishing';
+    }
+
+    if (
+      modelName &&
+      publishState.current === 'publishing' &&
+      publishProgress.success.find(model => model.modelName === modelName)
+    ) {
+      publishState.current = 'published';
+      refreshModelData();
+      return;
+    }
+  }, [publishRunning, publishProgress, modelName, isPublishingModel, fetchModelData]);
+
+  return (
+    <AdminHeader>
+      <AdminHeaderBlock
+        css={css`
+          position: relative;
+        `}
+      >
+        {headerText(modelName, error)}
+        <ModelStatusPillWithPublish name={modelName} data={response?.status} />
+        <ModelHeaderBackLink
+          to={manageModelsUrlBase}
+          css={css`
+            position: absolute;
+            left: 0;
+            bottom: 40px;
+          `}
+        >
+          <ArrowLeftIcon /> Back to List
+        </ModelHeaderBackLink>
+      </AdminHeaderBlock>
+      <AdminHeaderBlock>
+        {response.status &&
+        (response.status === modelStatus.published ||
+          response.status === modelStatus.unpublishedChanges) ? (
+          <ModelHeaderBackLink to={`/model/${modelName}`} target="_blank">
+            <ExternalLinkIcon
+              height={'10px'}
+              width={'10px'}
               css={css`
-                position: absolute;
-                left: 0;
-                bottom: 40px;
+                margin-right: 8px;
               `}
-            >
-              <ArrowLeftIcon /> Back to List
-            </ModelHeaderBackLink>
-          </AdminHeaderBlock>
-          <AdminHeaderBlock>
-            {response.status &&
-            (response.status === modelStatus.published ||
-              response.status === modelStatus.unpublishedChanges) ? (
-              <ModelHeaderBackLink to={`/model/${modelName}`} target="_blank">
-                <ExternalLinkIcon
-                  height={'10px'}
-                  width={'10px'}
-                  css={css`
-                    margin-right: 8px;
-                  `}
-                  fill={'currentColor'}
-                />
-                View in Catalog
-              </ModelHeaderBackLink>
-            ) : (
-              ''
-            )}
-            <PublishModel marginLeft="18px" marginRight="8px" />
-            <SaveModel />
-            {modelMoreOptions(response || null)}
-          </AdminHeaderBlock>
-        </AdminHeader>
-      </>
-    )}
-  </ModelSingleContext.Consumer>
-);
+              fill={'currentColor'}
+            />
+            View in Catalog
+          </ModelHeaderBackLink>
+        ) : (
+          ''
+        )}
+        <PublishModel marginLeft="18px" marginRight="8px" />
+        <SaveModel />
+        {modelMoreOptions(response || null)}
+      </AdminHeaderBlock>
+    </AdminHeader>
+  );
+};
 
 export default ModelSingleHeader;

--- a/ui/src/components/admin/Model/actions/Publish.js
+++ b/ui/src/components/admin/Model/actions/Publish.js
@@ -1,0 +1,77 @@
+import { get, post } from './../../services/Fetcher';
+import config from './../../config';
+
+const PUBLISH_URL = `${config.urls.cmsBase}/publish`;
+
+export const checkPublishStatus = async () => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${PUBLISH_URL}/status`;
+    await get({ url })
+      .then(res => {
+        resolve(res.data);
+      })
+      .catch(err => {
+        reject(err.response ? err.response.data.error : err);
+      });
+  });
+};
+
+export const publish = async modelName => {
+  const url = `${PUBLISH_URL}/${modelName}`;
+  return post({ url });
+};
+
+export const publishBulk = async models => {
+  const url = `${PUBLISH_URL}/bulk`;
+  return post({
+    url,
+    data: {
+      models,
+      ids: true,
+    },
+  });
+};
+
+export const acknowledgePublishStatus = async modelName => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${PUBLISH_URL}/acknowledge/${modelName}`;
+    await post({ url })
+      .then(res => {
+        resolve(res.data);
+      })
+      .catch(err => {
+        reject(err.response ? err.response.data.error : err);
+      });
+  });
+};
+
+export const acknowledgeBulkPublishStatus = async models => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${PUBLISH_URL}/acknowledge/bulk`;
+    await post({
+      url,
+      data: {
+        models,
+      },
+    })
+      .then(res => {
+        resolve(res.data);
+      })
+      .catch(err => {
+        reject(err.response ? err.response.data.error : err);
+      });
+  });
+};
+
+export const stopAllPublishes = async () => {
+  return new Promise(async (resolve, reject) => {
+    const url = `${PUBLISH_URL}/stop/all`;
+    await post({ url })
+      .then(res => {
+        resolve(res.data);
+      })
+      .catch(err => {
+        reject(err.response ? err.response.data.error : err);
+      });
+  });
+};

--- a/ui/src/components/admin/Model/actions/PublishModel.js
+++ b/ui/src/components/admin/Model/actions/PublishModel.js
@@ -2,6 +2,8 @@ import React from 'react';
 import Tooltip from '../../ToolTip';
 
 import { ModelSingleContext } from '../ModelSingleController';
+import { usePublishNotifications } from 'components/admin/Notifications';
+import { publish } from './Publish';
 
 import { ButtonPill } from 'theme/adminControlsStyles';
 import PublishIcon from 'icons/PublishIcon';
@@ -10,46 +12,64 @@ import withPublishConfirmModal from '../../PublishLinkedModelsModal/PublishLinke
 
 import { modelStatus } from '@hcmi-portal/cms/src/helpers/modelStatus';
 
-const PublishModel = ({ close, ...props }) => (
-  <ModelSingleContext.Consumer>
-    {({
-      state: {
-        form: { isReadyToPublish, values, errors },
-        matchedModels,
-      },
-      publishForm,
-    }) => {
-      const disabled = !isReadyToPublish;
-      return (
-        <Tooltip
-          trigger={() =>
-            withPublishConfirmModal({
-              disabled,
-              next: () => isReadyToPublish && publishForm(values),
-              modelNames: matchedModels
-                .filter(i => i.status === modelStatus.unpublishedChanges)
-                .map(i => i.name),
-            })(
-              <div>
-                <ButtonPill primary disabled={disabled} {...props}>
-                  <PublishIcon />
-                  Publish
-                </ButtonPill>
-              </div>,
-            )
-          }
-          disabled={isReadyToPublish}
-        >
-          {Object.keys(errors).length > 0 || !values.name
-            ? 'Please complete all required fields before publishing'
-            : !isReadyToPublish
-            ? 'No new changes to publish'
-            : // If a user hovers for 1000 seconds ...
-              'Ready to Publish =)'}
-        </Tooltip>
-      );
-    }}
-  </ModelSingleContext.Consumer>
-);
+const PublishModel = ({ close, ...props }) => {
+  const {
+    isPublishingModel,
+    addPublishNotification,
+    showErrorPublishNotification,
+  } = usePublishNotifications();
+
+  const publishForm = async modelName => {
+    await publish(modelName)
+      .then(async () => {
+        await addPublishNotification(modelName);
+      })
+      .catch(async error => {
+        const data = error.response ? error.response.data : error;
+        showErrorPublishNotification(modelName, data);
+      });
+  };
+
+  return (
+    <ModelSingleContext.Consumer>
+      {({
+        state: {
+          form: { isReadyToPublish, values, errors },
+          matchedModels,
+        },
+      }) => {
+        const disabled = !isReadyToPublish || isPublishingModel(values.name);
+        return (
+          <Tooltip
+            trigger={() =>
+              withPublishConfirmModal({
+                disabled,
+                next: () => isReadyToPublish && publishForm(values.name),
+                modelNames: matchedModels
+                  .filter(i => i.status === modelStatus.unpublishedChanges)
+                  .map(i => i.name),
+              })(
+                <div>
+                  <ButtonPill primary disabled={disabled} {...props}>
+                    <PublishIcon />
+                    Publish
+                  </ButtonPill>
+                </div>,
+              )
+            }
+            disabled={isReadyToPublish}
+          >
+            {Object.keys(errors).length > 0 || !values.name
+              ? 'Please complete all required fields before publishing'
+              : !isReadyToPublish
+              ? 'No new changes to publish'
+              : // If a user hovers for 1000 seconds ...
+                'Ready to Publish =)'}
+          </Tooltip>
+        );
+      }}
+    </ModelSingleContext.Consumer>
+  );
+};
 
 export default PublishModel;

--- a/ui/src/components/admin/Model/actions/PublishModel.js
+++ b/ui/src/components/admin/Model/actions/PublishModel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import Tooltip from '../../ToolTip';
 
 import { ModelSingleContext } from '../ModelSingleController';
@@ -14,10 +14,17 @@ import { modelStatus } from '@hcmi-portal/cms/src/helpers/modelStatus';
 
 const PublishModel = ({ close, ...props }) => {
   const {
+    state: {
+      form: { isReadyToPublish, values, errors },
+      matchedModels,
+    },
+  } = useContext(ModelSingleContext);
+  const {
     isPublishingModel,
     addPublishNotification,
     showErrorPublishNotification,
   } = usePublishNotifications();
+  const disabled = !isReadyToPublish || isPublishingModel(values.name);
 
   const publishForm = async modelName => {
     await publish(modelName)
@@ -31,44 +38,32 @@ const PublishModel = ({ close, ...props }) => {
   };
 
   return (
-    <ModelSingleContext.Consumer>
-      {({
-        state: {
-          form: { isReadyToPublish, values, errors },
-          matchedModels,
-        },
-      }) => {
-        const disabled = !isReadyToPublish || isPublishingModel(values.name);
-        return (
-          <Tooltip
-            trigger={() =>
-              withPublishConfirmModal({
-                disabled,
-                next: () => isReadyToPublish && publishForm(values.name),
-                modelNames: matchedModels
-                  .filter(i => i.status === modelStatus.unpublishedChanges)
-                  .map(i => i.name),
-              })(
-                <div>
-                  <ButtonPill primary disabled={disabled} {...props}>
-                    <PublishIcon />
-                    Publish
-                  </ButtonPill>
-                </div>,
-              )
-            }
-            disabled={isReadyToPublish}
-          >
-            {Object.keys(errors).length > 0 || !values.name
-              ? 'Please complete all required fields before publishing'
-              : !isReadyToPublish
-              ? 'No new changes to publish'
-              : // If a user hovers for 1000 seconds ...
-                'Ready to Publish =)'}
-          </Tooltip>
-        );
-      }}
-    </ModelSingleContext.Consumer>
+    <Tooltip
+      trigger={() =>
+        withPublishConfirmModal({
+          disabled,
+          next: () => isReadyToPublish && publishForm(values.name),
+          modelNames: matchedModels
+            .filter(i => i.status === modelStatus.unpublishedChanges)
+            .map(i => i.name),
+        })(
+          <div>
+            <ButtonPill primary disabled={disabled} {...props}>
+              <PublishIcon />
+              Publish
+            </ButtonPill>
+          </div>,
+        )
+      }
+      disabled={isReadyToPublish}
+    >
+      {Object.keys(errors).length > 0 || !values.name
+        ? 'Please complete all required fields before publishing'
+        : !isReadyToPublish
+        ? 'No new changes to publish'
+        : // If a user hovers for 1000 seconds ...
+          'Ready to Publish =)'}
+    </Tooltip>
   );
 };
 

--- a/ui/src/components/admin/Model/actions/SaveModel.js
+++ b/ui/src/components/admin/Model/actions/SaveModel.js
@@ -1,40 +1,45 @@
 import React from 'react';
 import { ModelSingleContext } from '../ModelSingleController';
+import { usePublishNotifications } from 'components/admin/Notifications';
 import { ButtonPill } from 'theme/adminControlsStyles';
 import SaveIcon from 'icons/SaveIcon';
 
-const SaveModel = props => (
-  <ModelSingleContext.Consumer>
-    {({
-      state: {
-        form: { values, isReadyToSave },
-        ui: { activeTab },
-      },
-      saveForm,
-    }) => (
-      <ButtonPill
-        primary
-        disabled={!isReadyToSave}
-        onClick={async () => {
-          if (isReadyToSave) {
-            switch (activeTab) {
-              case 'edit':
-                saveForm({ values });
-                break;
-              case 'images':
-                break;
-              default:
-                break;
+const SaveModel = props => {
+  const { isPublishingModel } = usePublishNotifications();
+
+  return (
+    <ModelSingleContext.Consumer>
+      {({
+        state: {
+          form: { values, isReadyToSave },
+          ui: { activeTab },
+        },
+        saveForm,
+      }) => (
+        <ButtonPill
+          primary
+          disabled={!isReadyToSave || isPublishingModel(values.name)}
+          onClick={async () => {
+            if (isReadyToSave) {
+              switch (activeTab) {
+                case 'edit':
+                  saveForm({ values });
+                  break;
+                case 'images':
+                  break;
+                default:
+                  break;
+              }
             }
-          }
-        }}
-        {...props}
-      >
-        <SaveIcon />
-        Save
-      </ButtonPill>
-    )}
-  </ModelSingleContext.Consumer>
-);
+          }}
+          {...props}
+        >
+          <SaveIcon />
+          Save
+        </ButtonPill>
+      )}
+    </ModelSingleContext.Consumer>
+  );
+};
 
 export default SaveModel;

--- a/ui/src/components/admin/Model/actions/SaveModel.js
+++ b/ui/src/components/admin/Model/actions/SaveModel.js
@@ -1,44 +1,41 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { ModelSingleContext } from '../ModelSingleController';
 import { usePublishNotifications } from 'components/admin/Notifications';
 import { ButtonPill } from 'theme/adminControlsStyles';
 import SaveIcon from 'icons/SaveIcon';
 
 const SaveModel = props => {
+  const {
+    state: {
+      form: { values, isReadyToSave },
+      ui: { activeTab },
+    },
+    saveForm,
+  } = useContext(ModelSingleContext);
   const { isPublishingModel } = usePublishNotifications();
 
   return (
-    <ModelSingleContext.Consumer>
-      {({
-        state: {
-          form: { values, isReadyToSave },
-          ui: { activeTab },
-        },
-        saveForm,
-      }) => (
-        <ButtonPill
-          primary
-          disabled={!isReadyToSave || isPublishingModel(values.name)}
-          onClick={async () => {
-            if (isReadyToSave) {
-              switch (activeTab) {
-                case 'edit':
-                  saveForm({ values });
-                  break;
-                case 'images':
-                  break;
-                default:
-                  break;
-              }
-            }
-          }}
-          {...props}
-        >
-          <SaveIcon />
-          Save
-        </ButtonPill>
-      )}
-    </ModelSingleContext.Consumer>
+    <ButtonPill
+      primary
+      disabled={!isReadyToSave || isPublishingModel(values.name)}
+      onClick={async () => {
+        if (isReadyToSave) {
+          switch (activeTab) {
+            case 'edit':
+              saveForm({ values });
+              break;
+            case 'images':
+              break;
+            default:
+              break;
+          }
+        }
+      }}
+      {...props}
+    >
+      <SaveIcon />
+      Save
+    </ButtonPill>
   );
 };
 

--- a/ui/src/components/admin/ModelsManager/ModelManagerController.js
+++ b/ui/src/components/admin/ModelsManager/ModelManagerController.js
@@ -12,8 +12,13 @@ import {
 } from '../helpers';
 
 import { getPageData, getCountData } from '../helpers/fetchTableData';
+import { publish, publishBulk } from '../Model/actions/Publish';
 import { ModelTableColumns } from './ModelColumns';
-import { NotificationsContext, NOTIFICATION_TYPES } from '../Notifications';
+import {
+  NotificationsContext,
+  NOTIFICATION_TYPES,
+  PublishNotificationsContext,
+} from '../Notifications';
 import { debounce } from 'lodash';
 import {
   importBulkGenomicVariants,
@@ -115,350 +120,356 @@ Model table state transitions for each action:
 */
 const ModelManagerController = ({ baseUrl, cmsBase, children, ...props }) => (
   <NotificationsContext.Consumer>
-    {({ appendNotification, importProgress, setImportProgress }) => (
-      <Component
-        initialState={{
-          minRows: 0,
-          scrollbarSize: {
-            scrollbarWidth: 10,
-          },
-          filterValue: '',
-          data: [],
-          isLoading: false,
-          error: null,
-          rowCount: 0,
-          ...initPagingState,
-        }}
-        didMount={async ({ state, setState }) => {
-          try {
-            const [dataResponse, countResponse] = await loadData(baseUrl, state);
-            setState(() => ({
+    {({
+      appendNotification,
+      importProgress,
+      setImportProgress,
+      publishProgress,
+      setPublishProgress,
+    }) => (
+      <PublishNotificationsContext.Consumer>
+        {({ addPublishNotification, showErrorPublishNotification }) => (
+          <Component
+            initialState={{
+              minRows: 0,
+              scrollbarSize: {
+                scrollbarWidth: 10,
+              },
+              filterValue: '',
+              data: [],
               isLoading: false,
-              data: dataResponse.data,
               error: null,
-              rowCount: countResponse.data.count,
-            }));
-          } catch (err) {
-            setState(() => ({ isLoading: false, data: [], error: err }));
-          }
-        }}
-        // only debounce data load on updates -- this is primarily to prevent too many data fetches as user is filtering the table
-        didUpdate={debounce(
-          async ({ state, setState, prevState }) => {
-            if (
-              state.pageSize !== prevState.pageSize ||
-              state.page !== prevState.page ||
-              state.filterValue !== prevState.filterValue ||
-              state.sorted !== prevState.sorted
-            ) {
+              rowCount: 0,
+              ...initPagingState,
+            }}
+            didMount={async ({ state, setState }) => {
               try {
-                setState({
-                  isLoading: true,
-                  data: [],
-                  error: null,
-                  rowCount: 0,
-                });
                 const [dataResponse, countResponse] = await loadData(baseUrl, state);
                 setState(() => ({
                   isLoading: false,
                   data: dataResponse.data,
                   error: null,
                   rowCount: countResponse.data.count,
-                  selection: [],
-                  selectAll: false,
                 }));
               } catch (err) {
                 setState(() => ({ isLoading: false, data: [], error: err }));
               }
-            }
-          },
-          300,
-          { maxWait: 1000, trailing: true },
-        )}
-      >
-        {({ state, setState }) => (
-          <ModelManagerContext.Provider
-            value={{
-              state,
-              uploadModelsFromSheet: async (sheetURL, overwrite, overwriteVariants) => {
-                // Set loading true (lock UI)
-                await setState({
-                  isLoading: true,
-                });
-
-                uploadModelsFromSheet(sheetURL, overwrite)
-                  .then(({ data: { result } }) =>
-                    loadData(baseUrl, state).then(async ([dataResponse, countResponse]) => {
-                      await setState({
-                        isLoading: false,
-                        data: dataResponse.data,
-                        error: null,
-                        rowCount: countResponse.data.count,
-                        ...initPagingState,
-                      });
-                      const anyUpdatesDone = isEmptyResult(result);
-                      const notificationMessage = anyUpdatesDone
-                        ? `No suitable data is available to upload. No changes were made.`
-                        : `Bulk Upload of models has successfully completed. New models or updated fields are saved but not yet published.`;
-                      await appendNotification({
-                        type:
-                          result.errors.length > 0
-                            ? NOTIFICATION_TYPES.WARNING
-                            : NOTIFICATION_TYPES.SUCCESS,
-                        message: notificationMessage,
-                        details: anyUpdatesDone ? '' : extractResultText(result),
-                        bulkErrors: result.errors,
-                        timeout: false, // do not auto-remove this notification
-                      });
-                      let modelNames;
-                      switch (overwriteVariants) {
-                        case VARIANT_OVERWRITE_OPTIONS.allModels:
-                          modelNames = [...result.new, ...result.updated, ...result.unchanged];
-                          if (!modelNames.length) {
-                            return;
-                          }
-
-                          await importBulkGenomicVariants(modelNames)
-                            .then(response => {
-                              if (response.data.success) {
-                                setImportProgress({
-                                  ...importProgress,
-                                  running: true,
-                                });
-                              }
-                            })
-                            .catch(async error => {
-                              await appendNotification({
-                                type: NOTIFICATION_TYPES.ERROR,
-                                message: 'Bulk Import of Research Somatic Variants Failed.',
-                                details: error.response
-                                  ? error.response.data.error.message
-                                  : error.message,
-                                timeout: false,
-                              });
-                            });
-                          break;
-                        case VARIANT_OVERWRITE_OPTIONS.cleanOnly:
-                          modelNames = [...result.new, ...result.updated, ...result.unchanged];
-                          if (!modelNames.length) {
-                            return;
-                          }
-
-                          const checkVariantsResponse = await auditGenomicVariantsSpecificModels(
-                            modelNames,
-                          );
-                          await importBulkGenomicVariants(checkVariantsResponse.data.clean)
-                            .then(response => {
-                              if (response.data.success) {
-                                setImportProgress({
-                                  ...importProgress,
-                                  running: true,
-                                });
-                              }
-                            })
-                            .catch(async error => {
-                              await appendNotification({
-                                type: NOTIFICATION_TYPES.ERROR,
-                                message: 'Bulk Import of Research Somatic Variants Failed.',
-                                details: error.response
-                                  ? error.response.data.error.message
-                                  : error.message,
-                                timeout: false,
-                              });
-                            });
-                          break;
-                        case VARIANT_OVERWRITE_OPTIONS.none:
-                        default:
-                          break;
-                      }
-                    }),
-                  )
-                  .catch(async err => {
-                    const errorText = extractErrorText(err);
-
-                    await setState({
+            }}
+            // only debounce data load on updates -- this is primarily to prevent too many data fetches as user is filtering the table
+            didUpdate={debounce(
+              async ({ state, setState, prevState }) => {
+                if (
+                  state.pageSize !== prevState.pageSize ||
+                  state.page !== prevState.page ||
+                  state.filterValue !== prevState.filterValue ||
+                  state.sorted !== prevState.sorted
+                ) {
+                  try {
+                    setState({
+                      isLoading: true,
+                      data: [],
+                      error: null,
+                      rowCount: 0,
+                    });
+                    const [dataResponse, countResponse] = await loadData(baseUrl, state);
+                    setState(() => ({
                       isLoading: false,
+                      data: dataResponse.data,
+                      error: null,
+                      rowCount: countResponse.data.count,
+                      selection: [],
+                      selectAll: false,
+                    }));
+                  } catch (err) {
+                    setState(() => ({ isLoading: false, data: [], error: err }));
+                  }
+                }
+              },
+              300,
+              { maxWait: 1000, trailing: true },
+            )}
+          >
+            {({ state, setState }) => (
+              <ModelManagerContext.Provider
+                value={{
+                  state,
+                  uploadModelsFromSheet: async (sheetURL, overwrite, overwriteVariants) => {
+                    // Set loading true (lock UI)
+                    await setState({
+                      isLoading: true,
                     });
 
-                    await appendNotification({
-                      type: NOTIFICATION_TYPES.ERROR,
-                      message: 'Model Upload Error.',
-                      details: errorText.length > 0 ? errorText : 'Unknown error has occurred.',
-                    });
-                  });
-              },
-              bulkImportVariants: async modelNames => {
-                return importBulkGenomicVariants(modelNames)
-                  .then(response => {
-                    if (response.data.success) {
-                      setImportProgress({
-                        ...importProgress,
-                        running: true,
+                    uploadModelsFromSheet(sheetURL, overwrite)
+                      .then(({ data: { result } }) =>
+                        loadData(baseUrl, state).then(async ([dataResponse, countResponse]) => {
+                          await setState({
+                            isLoading: false,
+                            data: dataResponse.data,
+                            error: null,
+                            rowCount: countResponse.data.count,
+                            ...initPagingState,
+                          });
+                          const anyUpdatesDone = isEmptyResult(result);
+                          const notificationMessage = anyUpdatesDone
+                            ? `No suitable data is available to upload. No changes were made.`
+                            : `Bulk Upload of models has successfully completed. New models or updated fields are saved but not yet published.`;
+                          await appendNotification({
+                            type:
+                              result.errors.length > 0
+                                ? NOTIFICATION_TYPES.WARNING
+                                : NOTIFICATION_TYPES.SUCCESS,
+                            message: notificationMessage,
+                            details: anyUpdatesDone ? '' : extractResultText(result),
+                            bulkErrors: result.errors,
+                            timeout: false, // do not auto-remove this notification
+                          });
+                          let modelNames;
+                          switch (overwriteVariants) {
+                            case VARIANT_OVERWRITE_OPTIONS.allModels:
+                              modelNames = [...result.new, ...result.updated, ...result.unchanged];
+                              if (!modelNames.length) {
+                                return;
+                              }
+
+                              await importBulkGenomicVariants(modelNames)
+                                .then(response => {
+                                  if (response.data.success) {
+                                    setImportProgress({
+                                      ...importProgress,
+                                      running: true,
+                                    });
+                                  }
+                                })
+                                .catch(async error => {
+                                  await appendNotification({
+                                    type: NOTIFICATION_TYPES.ERROR,
+                                    message: 'Bulk Import of Research Somatic Variants Failed.',
+                                    details: error.response
+                                      ? error.response.data.error.message
+                                      : error.message,
+                                    timeout: false,
+                                  });
+                                });
+                              break;
+                            case VARIANT_OVERWRITE_OPTIONS.cleanOnly:
+                              modelNames = [...result.new, ...result.updated, ...result.unchanged];
+                              if (!modelNames.length) {
+                                return;
+                              }
+
+                              const checkVariantsResponse = await auditGenomicVariantsSpecificModels(
+                                modelNames,
+                              );
+                              await importBulkGenomicVariants(checkVariantsResponse.data.clean)
+                                .then(response => {
+                                  if (response.data.success) {
+                                    setImportProgress({
+                                      ...importProgress,
+                                      running: true,
+                                    });
+                                  }
+                                })
+                                .catch(async error => {
+                                  await appendNotification({
+                                    type: NOTIFICATION_TYPES.ERROR,
+                                    message: 'Bulk Import of Research Somatic Variants Failed.',
+                                    details: error.response
+                                      ? error.response.data.error.message
+                                      : error.message,
+                                    timeout: false,
+                                  });
+                                });
+                              break;
+                            case VARIANT_OVERWRITE_OPTIONS.none:
+                            default:
+                              break;
+                          }
+                        }),
+                      )
+                      .catch(async err => {
+                        const errorText = extractErrorText(err);
+
+                        await setState({
+                          isLoading: false,
+                        });
+
+                        await appendNotification({
+                          type: NOTIFICATION_TYPES.ERROR,
+                          message: 'Model Upload Error.',
+                          details: errorText.length > 0 ? errorText : 'Unknown error has occurred.',
+                        });
                       });
-                    }
-                  })
-                  .catch(async error => {
-                    await appendNotification({
-                      type: NOTIFICATION_TYPES.ERROR,
-                      message: 'Bulk Import of Research Somatic Variants Failed.',
-                      details: error.response ? error.response.data.error.message : error.message,
+                  },
+                  bulkImportVariants: async modelNames => {
+                    return importBulkGenomicVariants(modelNames)
+                      .then(response => {
+                        if (response.data.success) {
+                          setImportProgress({
+                            ...importProgress,
+                            running: true,
+                          });
+                        }
+                      })
+                      .catch(async error => {
+                        await appendNotification({
+                          type: NOTIFICATION_TYPES.ERROR,
+                          message: 'Bulk Import of Research Somatic Variants Failed.',
+                          details: error.response
+                            ? error.response.data.error.message
+                            : error.message,
+                          timeout: false,
+                        });
+                      });
+                  },
+                  bulkPublish: async () => {
+                    // display a temporary notification immediately while waiting for the server response
+                    const tempNotification = await appendNotification({
+                      type: NOTIFICATION_TYPES.LOADING,
+                      message: 'Initiating Bulk Publish...',
+                      details:
+                        'You can continue to use the CMS and will be notified when the publish is complete. Please note that some functions are unavailable during the publish process.',
                       timeout: false,
                     });
-                  });
-              },
-              bulkPublish: bulkActionCreator({
-                action: 'publish',
-                baseUrl,
-                state,
-                setState,
-                appendNotification,
-              }),
-              bulkUnpublish: bulkActionCreator({
-                action: 'unpublish',
-                baseUrl,
-                state,
-                setState,
-                appendNotification,
-              }),
-              bulkDelete: bulkActionCreator({
-                action: 'delete',
-                baseUrl,
-                state,
-                setState,
-                appendNotification,
-              }),
-              publishOne: async name => {
-                // Set loading true (lock UI)
-                await setState({
-                  isLoading: true,
-                });
-
-                singleAction('publish', name)
-                  .then(() => loadData(baseUrl, state))
-                  .then(async ([dataResponse, countResponse]) => {
+                    await publishBulk(state.selection)
+                      .then(async response => {
+                        if (response.data.success) {
+                          await setPublishProgress({
+                            ...publishProgress,
+                            running: true,
+                          });
+                          await tempNotification.clear();
+                        }
+                      })
+                      .catch(async error => {
+                        await appendNotification({
+                          type: NOTIFICATION_TYPES.ERROR,
+                          message: 'Bulk Publish Failed.',
+                          details: error.response
+                            ? error.response.data.error.message
+                            : error.message,
+                          timeout: false,
+                        });
+                        await tempNotification.clear();
+                      });
+                  },
+                  bulkUnpublish: bulkActionCreator({
+                    action: 'unpublish',
+                    baseUrl,
+                    state,
+                    setState,
+                    appendNotification,
+                  }),
+                  bulkDelete: bulkActionCreator({
+                    action: 'delete',
+                    baseUrl,
+                    state,
+                    setState,
+                    appendNotification,
+                  }),
+                  publishOne: async name => {
+                    await publish(name)
+                      .then(async () => {
+                        await addPublishNotification(name);
+                      })
+                      .catch(async error => {
+                        const data = error.response ? error.response.data : error;
+                        showErrorPublishNotification(name, data);
+                      });
+                  },
+                  unpublishOne: async name => {
+                    // Set loading true (lock UI)
                     await setState({
+                      isLoading: true,
+                    });
+
+                    singleAction('unpublish', name)
+                      .then(() => loadData(baseUrl, state))
+                      .then(async ([dataResponse, countResponse]) => {
+                        await setState(() => ({
+                          isLoading: false,
+                          data: dataResponse.data,
+                          error: null,
+                          rowCount: countResponse.data.count,
+                        }));
+
+                        await appendNotification({
+                          type: NOTIFICATION_TYPES.SUCCESS,
+                          message: `Unpublish Successful!`,
+                          details: `${name} has been successfully unpublished`,
+                        });
+                      })
+                      .catch(async err => {
+                        const errorText = extractErrorText(err);
+
+                        await setState({
+                          isLoading: false,
+                          error: err,
+                        });
+
+                        await appendNotification({
+                          type: NOTIFICATION_TYPES.ERROR,
+                          message: `Unpublish Error.`,
+                          details: errorText.length > 0 ? errorText : 'Unknown error has occurred.',
+                          timeout: false, // do not auto-remove this notification when unpublishing
+                        });
+                      });
+                  },
+                  deleteOne: async name => {
+                    // Set loading true (lock UI)
+                    await setState({ isLoading: true });
+
+                    singleAction('delete', name)
+                      .then(() => loadData(baseUrl, state))
+                      .then(async ([dataResponse, countResponse]) => {
+                        await setState(() => ({
+                          isLoading: false,
+                          data: dataResponse.data,
+                          error: null,
+                          rowCount: countResponse.data.count,
+                        }));
+
+                        await appendNotification({
+                          type: NOTIFICATION_TYPES.SUCCESS,
+                          message: `Delete Successful!`,
+                          details: `${name} has been successfully deleted`,
+                        });
+                      })
+                      .catch(async err => {
+                        const errorText = extractErrorText(err);
+
+                        await setState({
+                          isLoading: false,
+                          error: err,
+                        });
+
+                        await appendNotification({
+                          type: NOTIFICATION_TYPES.ERROR,
+                          message: `Delete Error.`,
+                          details: errorText.length > 0 ? errorText : 'Unknown error has occurred.',
+                          timeout: false, // do not auto-remove this notification when deleting
+                        });
+                      });
+                  },
+                  refreshModelsTable: async () => {
+                    const [dataResponse, countResponse] = await loadData(baseUrl, state);
+                    setState(() => ({
                       isLoading: false,
                       data: dataResponse.data,
                       error: null,
                       rowCount: countResponse.data.count,
-                    });
-
-                    await appendNotification({
-                      type: NOTIFICATION_TYPES.SUCCESS,
-                      message: `Publish Successful!`,
-                      details: `${name} has been successfully published. View it live here: `,
-                      link: `/model/${name}`,
-                      linkText: name,
-                    });
-                  })
-                  .catch(async err => {
-                    const errorText = extractErrorText(err);
-
-                    await setState({
-                      isLoading: false,
-                      error: err,
-                    });
-
-                    await appendNotification({
-                      type: NOTIFICATION_TYPES.ERROR,
-                      message: `Publish Error.`,
-                      details: errorText.length > 0 ? errorText : 'Unknown error has occurred.',
-                      timeout: false, // do not auto-remove this notification when publishing
-                    });
-                  });
-              },
-              unpublishOne: async name => {
-                // Set loading true (lock UI)
-                await setState({
-                  isLoading: true,
-                });
-
-                singleAction('unpublish', name)
-                  .then(() => loadData(baseUrl, state))
-                  .then(async ([dataResponse, countResponse]) => {
-                    await setState(() => ({
-                      isLoading: false,
-                      data: dataResponse.data,
-                      error: null,
-                      rowCount: countResponse.data.count,
+                      ...initPagingState,
                     }));
-
-                    await appendNotification({
-                      type: NOTIFICATION_TYPES.SUCCESS,
-                      message: `Unpublish Successful!`,
-                      details: `${name} has been successfully unpublished`,
-                    });
-                  })
-                  .catch(async err => {
-                    const errorText = extractErrorText(err);
-
-                    await setState({
-                      isLoading: false,
-                      error: err,
-                    });
-
-                    await appendNotification({
-                      type: NOTIFICATION_TYPES.ERROR,
-                      message: `Unpublish Error.`,
-                      details: errorText.length > 0 ? errorText : 'Unknown error has occurred.',
-                      timeout: false, // do not auto-remove this notification when unpublishing
-                    });
-                  });
-              },
-              deleteOne: async name => {
-                // Set loading true (lock UI)
-                await setState({ isLoading: true });
-
-                singleAction('delete', name)
-                  .then(() => loadData(baseUrl, state))
-                  .then(async ([dataResponse, countResponse]) => {
-                    await setState(() => ({
-                      isLoading: false,
-                      data: dataResponse.data,
-                      error: null,
-                      rowCount: countResponse.data.count,
-                    }));
-
-                    await appendNotification({
-                      type: NOTIFICATION_TYPES.SUCCESS,
-                      message: `Delete Successful!`,
-                      details: `${name} has been successfully deleted`,
-                    });
-                  })
-                  .catch(async err => {
-                    const errorText = extractErrorText(err);
-
-                    await setState({
-                      isLoading: false,
-                      error: err,
-                    });
-
-                    await appendNotification({
-                      type: NOTIFICATION_TYPES.ERROR,
-                      message: `Delete Error.`,
-                      details: errorText.length > 0 ? errorText : 'Unknown error has occurred.',
-                      timeout: false, // do not auto-remove this notification when deleting
-                    });
-                  });
-              },
-              refreshModelsTable: async () => {
-                const [dataResponse, countResponse] = await loadData(baseUrl, state);
-                setState(() => ({
-                  isLoading: false,
-                  data: dataResponse.data,
-                  error: null,
-                  rowCount: countResponse.data.count,
-                  ...initPagingState,
-                }));
-              },
-              ...generateTableActions(setState, state.data),
-            }}
-            {...props}
-          >
-            {children}
-          </ModelManagerContext.Provider>
+                  },
+                  ...generateTableActions(setState, state.data),
+                }}
+                {...props}
+              >
+                {children}
+              </ModelManagerContext.Provider>
+            )}
+          </Component>
         )}
-      </Component>
+      </PublishNotificationsContext.Consumer>
     )}
   </NotificationsContext.Consumer>
 );

--- a/ui/src/components/admin/ModelsManager/ModelManagerController.js
+++ b/ui/src/components/admin/ModelsManager/ModelManagerController.js
@@ -346,7 +346,7 @@ const ModelManagerController = ({ baseUrl, cmsBase, children, ...props }) => (
                           message: 'Bulk Publish Failed.',
                           details: error.response
                             ? error.response.data.error.message
-                            : error.message,
+                            : error?.error?.message || error?.message || error,
                           timeout: false,
                         });
                         await tempNotification.clear();

--- a/ui/src/components/admin/ModelsManager/ModelsManager.js
+++ b/ui/src/components/admin/ModelsManager/ModelsManager.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import ModelManagerProvider, { ModelManagerContext } from './ModelManagerController';
 import { ModalStateContext } from 'providers/ModalState';
+import { usePublishNotifications } from 'components/admin/Notifications';
 
 import { NotificationToaster } from '../Notifications';
 import ModelManagerTable from './ModelManagerTable';
@@ -20,7 +21,9 @@ import { AdminModalStyle } from 'theme/adminModalStyles';
 import config from '../config';
 import { BULK_UPLOAD_TYPES } from 'utils/constants';
 
-const content = () => {
+const ModelsManager = () => {
+  const { publishRunning } = usePublishNotifications();
+
   return (
     <ModelManagerProvider cmsBase={config.urls.cmsBase} baseUrl={`${config.urls.cmsBase}/Model`}>
       <AdminContainer>
@@ -42,7 +45,7 @@ const content = () => {
                           styles: AdminModalStyle,
                         })
                       }
-                      disabled={state && state.isLoading}
+                      disabled={(state && state.isLoading) || publishRunning}
                     >
                       <DNAIcon />
                       Check for GDC Variants
@@ -71,7 +74,7 @@ const content = () => {
                           styles: AdminModalStyle,
                         })
                       }
-                      disabled={state && state.isLoading}
+                      disabled={(state && state.isLoading) || publishRunning}
                     >
                       <PlusIcon />
                       Add Bulk
@@ -94,4 +97,4 @@ const content = () => {
   );
 };
 
-export default content;
+export default ModelsManager;

--- a/ui/src/components/admin/Notifications/NotificationsController.js
+++ b/ui/src/components/admin/Notifications/NotificationsController.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { v4 as uuid } from 'uuid';
 
-import { DEFAULT_IMPORT_PROGRESS, DEFAULT_NONACTIONABLE_IMPORTS } from 'utils/constants';
+import { DEFAULT_PROGRESS_QUEUES, DEFAULT_NONACTIONABLE_IMPORTS } from 'utils/constants';
 
 export const NotificationsContext = React.createContext();
 
@@ -10,9 +10,13 @@ const NotificationsProvider = ({ location, children }) => {
   // only used for imports initiated from individual model pages
   const [importNotifications, setImportNotifications] = useState([]);
   // bulk variant import progress
-  const [importProgress, setImportProgress] = useState(DEFAULT_IMPORT_PROGRESS);
+  const [importProgress, setImportProgress] = useState(DEFAULT_PROGRESS_QUEUES);
   // models which failed variant import with nonactionable errors
   const [nonactionableImports, setNonactionableImports] = useState(DEFAULT_NONACTIONABLE_IMPORTS);
+  // only used for publishes initiated from individual model pages
+  const [publishNotifications, setPublishNotifications] = useState([]);
+  // bulk publish progress
+  const [publishProgress, setPublishProgress] = useState(DEFAULT_PROGRESS_QUEUES);
 
   const appendNotification = notification => {
     const id = uuid();
@@ -72,6 +76,10 @@ const NotificationsProvider = ({ location, children }) => {
         setImportProgress,
         nonactionableImports,
         setNonactionableImports,
+        publishNotifications,
+        setPublishNotifications,
+        publishProgress,
+        setPublishProgress,
         location,
       }}
     >

--- a/ui/src/components/admin/Notifications/ProgressBanner.js
+++ b/ui/src/components/admin/Notifications/ProgressBanner.js
@@ -216,7 +216,7 @@ const ProgressBanner = ({ renderIcon }) => {
   return (
     <Notification type={getProgressBannerType()}>
       {renderIcon(getProgressBannerType())}
-      <Col>
+      <Col style={{ maxWidth: '50%', width: '100%' }}>
         <Message>{getProgressBannerMessage()}</Message>
         <Details>{getProgressBannerDetails()}</Details>
       </Col>

--- a/ui/src/components/admin/Notifications/PublishNotifications.js
+++ b/ui/src/components/admin/Notifications/PublishNotifications.js
@@ -1,0 +1,324 @@
+import React, { useContext } from 'react';
+import { NotificationsContext } from './NotificationsController';
+import NOTIFICATION_TYPES from './NotificationTypes';
+import {
+  acknowledgePublishStatus,
+  checkPublishStatus,
+} from 'components/admin/Model/actions/Publish';
+import { PUBLISH_ERRORS, PUBLISH_TYPES } from 'utils/constants';
+
+export const PublishNotificationsContext = React.createContext([{}, () => {}]);
+
+export const PublishNotificationsProvider = ({ children }) => {
+  const {
+    notifications,
+    appendNotification,
+    clearNotification,
+    publishNotifications,
+    setPublishNotifications,
+    publishProgress,
+    setPublishProgress,
+  } = useContext(NotificationsContext);
+
+  // ONLY USED FOR INDIVIDUAL PUBLISHES
+  const getPublishNotifications = () => {
+    if (!publishNotifications) return [];
+    return publishNotifications;
+  };
+
+  const isPublishingModel = modelName => {
+    return getPublishNotifications().find(activePublish => activePublish.modelName === modelName) ||
+      (publishProgress.running &&
+        publishProgress.queue.find(queuedPublish => queuedPublish.modelName === modelName))
+      ? true
+      : false;
+  };
+
+  // ONLY USED FOR INDIVIDUAL PUBLISHES
+  const addPublishNotification = async modelName => {
+    const existingNotification = getPublishNotifications().find(x => x.modelName === modelName);
+
+    if (existingNotification) {
+      existingNotification.clear();
+    }
+
+    const notification = await appendNotification({
+      type: NOTIFICATION_TYPES.LOADING,
+      message: `Publishing: ${modelName}`,
+      details:
+        'You can continue to use the CMS and will be notified when the publish is complete. Please note that some functions are unavailable during the publish process.',
+      timeout: false,
+    });
+
+    setPublishNotifications(notifications => [
+      ...notifications.filter(notification => notification.modelName !== modelName),
+      {
+        modelName: modelName,
+        notificationId: notification.id,
+        clear: notification.clear,
+      },
+    ]);
+  };
+
+  // ONLY USED FOR INDIVIDUAL PUBLISHES
+  const removePublishNotification = modelName => {
+    const existingNotification = getPublishNotifications().find(x => x.modelName === modelName);
+
+    if (existingNotification) {
+      clearNotification(existingNotification.notificationId);
+      setPublishNotifications(notifications =>
+        notifications.filter(notification => notification.modelName !== modelName),
+      );
+    }
+  };
+
+  // ONLY USED FOR INDIVIDUAL PUBLISHES
+  const showSuccessfulPublishNotification = modelName => {
+    if (notifications.find(x => x.modelName === modelName)) {
+      return;
+    }
+
+    appendNotification({
+      type: NOTIFICATION_TYPES.SUCCESS,
+      message: 'Publish Successful!',
+      details: `${modelName} has been successfully published. View it live here: `,
+      link: `/model/${modelName}`,
+      linkText: modelName,
+      timeout: false,
+      modelName,
+      onClose: () => {
+        acknowledgeModelAndUpdateNotifications(modelName);
+      },
+    });
+  };
+
+  // ONLY USED FOR INDIVIDUAL PUBLISHES
+  const showStoppedPublishNotification = modelName => {
+    if (notifications.find(x => x.modelName === modelName)) {
+      return;
+    }
+
+    appendNotification({
+      type: NOTIFICATION_TYPES.ERROR,
+      message: `Publish Stopped: ${modelName} has not been published.`,
+      link: `/admin/model/${modelName}`,
+      linkText: 'View on model page to restart the publish.',
+      timeout: false,
+      modelName,
+      onClose: () => {
+        acknowledgeModelAndUpdateNotifications(modelName);
+      },
+    });
+  };
+
+  const showErrorPublishNotification = (modelName, error) => {
+    if (notifications.find(x => x.modelName === modelName)) {
+      return;
+    }
+
+    switch (error.error && error.error.code) {
+      case PUBLISH_ERRORS.noMatchingModel:
+        appendNotification({
+          type: NOTIFICATION_TYPES.ERROR,
+          message: 'Publish Error: Model Not Found',
+          details: `The model ${modelName} was not found in the HCMI database.`,
+          timeout: false,
+          modelName,
+          onClose: () => {
+            acknowledgeModelAndUpdateNotifications(modelName);
+          },
+        });
+        break;
+      case PUBLISH_ERRORS.badRequest:
+        appendNotification({
+          type: NOTIFICATION_TYPES.ERROR,
+          message: 'Publish Error: Bad Request',
+          details: `The publish request for ${modelName} was not formed correctly: ${
+            error.message
+          }`,
+          timeout: false,
+          modelName,
+          onClose: () => {
+            acknowledgeModelAndUpdateNotifications(modelName);
+          },
+        });
+        break;
+      case PUBLISH_ERRORS.validationErrror:
+        appendNotification({
+          type: NOTIFICATION_TYPES.ERROR,
+          message: `Publish Error: Validation Failed for ${modelName}`,
+          details: error.message,
+          timeout: false,
+          modelName,
+          onClose: () => {
+            acknowledgeModelAndUpdateNotifications(modelName);
+          },
+        });
+        break;
+      case PUBLISH_ERRORS.unexpected:
+      default:
+        appendNotification({
+          type: NOTIFICATION_TYPES.ERROR,
+          message: `Publish Error: An unexpected error occured while publishing ${modelName}`,
+          details: error.message,
+          timeout: false,
+          modelName,
+          onClose: () => {
+            acknowledgeModelAndUpdateNotifications(modelName);
+          },
+        });
+        break;
+    }
+  };
+
+  // Remove a model's error notification without triggering onClose function
+  const hideErrorPublishNotification = modelName => {
+    const existingNotification = notifications.find(x => x.modelName === modelName);
+
+    if (existingNotification) {
+      existingNotification.clear();
+    }
+  };
+
+  const showUnexpectedPublishError = error => {
+    appendNotification({
+      type: NOTIFICATION_TYPES.ERROR,
+      message: 'Publish Error: An unexpected error has occurred.',
+      details: error.message || error.details || error.name,
+      timeout: false,
+    });
+  };
+
+  const updatePublishNotificationsFromStatus = async () => {
+    const { queue, stopped, success, failed } = publishProgress;
+
+    // Add publish notifications for individual publishes in the queue
+    const individualQueuedPublishes = (queue || []).filter(
+      x => x.publishType === PUBLISH_TYPES.individual,
+    );
+    individualQueuedPublishes.forEach(publishTask => {
+      const modelName = publishTask.modelName;
+      if (!getPublishNotifications().find(x => x.modelName === modelName)) {
+        addPublishNotification(modelName);
+      }
+    });
+
+    // Remove publish notification and show stopped notification for stopped individual publishes
+    const individualStoppedPublishes = (stopped || []).filter(
+      x => x.publishType === PUBLISH_TYPES.individual,
+    );
+    individualStoppedPublishes.forEach(stoppedPublish => {
+      const modelName = stoppedPublish.modelName;
+      removePublishNotification(modelName);
+      showStoppedPublishNotification(modelName);
+    });
+
+    // Remove publish notification and show success notification for completed individual publishes
+    const individualCompletedPublishes = (success || []).filter(
+      x => x.publishType === PUBLISH_TYPES.individual,
+    );
+    individualCompletedPublishes.forEach(completedPublish => {
+      const modelName = completedPublish.modelName;
+      removePublishNotification(modelName);
+      showSuccessfulPublishNotification(modelName);
+    });
+
+    // Remove publish errors for re-queued bulk publishes (re-published)
+    const bulkQueuedPublishes = (queue || []).filter(x => x.publishType === PUBLISH_TYPES.bulk);
+    bulkQueuedPublishes.forEach(queuedPublish => {
+      const modelName = queuedPublish.modelName;
+      hideErrorPublishNotification(modelName);
+    });
+
+    // Remove publish errors for completed bulk publishes
+    const bulkCompletedPublishes = (success || []).filter(
+      x => x.publishType === PUBLISH_TYPES.bulk,
+    );
+    bulkCompletedPublishes.forEach(completedPublish => {
+      const modelName = completedPublish.modelName;
+      hideErrorPublishNotification(modelName);
+    });
+
+    // Add error notifications for failed publishes
+    const failedPublishes = failed || [];
+
+    failedPublishes.forEach(failedPublish => {
+      const modelName = failedPublish.modelName;
+
+      if (failedPublish.publishType === PUBLISH_TYPES.individual) {
+        removePublishNotification(modelName);
+      }
+
+      if (failedPublish.actionable || failedPublish.publishType === PUBLISH_TYPES.individual) {
+        // Actionable errors and errors for individual publishes get shown normally
+        showErrorPublishNotification(modelName, failedPublish);
+      }
+    });
+  };
+
+  const fetchPublishStatus = async () => {
+    await checkPublishStatus()
+      .then(publishStatus => {
+        setPublishProgress(publishStatus);
+      })
+      .catch(error => {
+        showUnexpectedPublishError(error);
+      });
+  };
+
+  const acknowledgeModelAndUpdateNotifications = async modelName => {
+    await acknowledgePublishStatus(modelName)
+      .then(async _ => {
+        await fetchPublishStatus();
+      })
+      .catch(error => {
+        showUnexpectedPublishError(error);
+      });
+  };
+
+  return (
+    <PublishNotificationsContext.Provider
+      value={{
+        publishNotifications: getPublishNotifications(),
+        addPublishNotification,
+        showErrorPublishNotification,
+        showUnexpectedPublishError,
+        updatePublishNotificationsFromStatus,
+        fetchPublishStatus,
+        hideErrorPublishNotification,
+        publishRunning: publishProgress.running,
+        isPublishingModel,
+      }}
+    >
+      {children}
+    </PublishNotificationsContext.Provider>
+  );
+};
+
+const usePublishNotifications = () => {
+  const {
+    publishNotifications,
+    addPublishNotification,
+    showErrorPublishNotification,
+    showUnexpectedPublishError,
+    updatePublishNotificationsFromStatus,
+    fetchPublishStatus,
+    hideErrorPublishNotification,
+    publishRunning,
+    isPublishingModel,
+  } = useContext(PublishNotificationsContext);
+
+  return {
+    publishNotifications,
+    addPublishNotification,
+    showErrorPublishNotification,
+    showUnexpectedPublishError,
+    updatePublishNotificationsFromStatus,
+    fetchPublishStatus,
+    hideErrorPublishNotification,
+    publishRunning,
+    isPublishingModel,
+  };
+};
+
+export default usePublishNotifications;

--- a/ui/src/components/admin/Notifications/PublishNotifications.js
+++ b/ui/src/components/admin/Notifications/PublishNotifications.js
@@ -6,6 +6,7 @@ import {
   checkPublishStatus,
 } from 'components/admin/Model/actions/Publish';
 import { PUBLISH_ERRORS, PUBLISH_TYPES } from 'utils/constants';
+import { ErrorsCol, ErrorLabel, ErrorsRow, ErrorText } from 'theme/adminNotificationStyles';
 
 export const PublishNotificationsContext = React.createContext([{}, () => {}]);
 
@@ -134,7 +135,7 @@ export const PublishNotificationsProvider = ({ children }) => {
           type: NOTIFICATION_TYPES.ERROR,
           message: 'Publish Error: Bad Request',
           details: `The publish request for ${modelName} was not formed correctly: ${
-            error.message
+            error.error.message
           }`,
           timeout: false,
           modelName,
@@ -147,7 +148,22 @@ export const PublishNotificationsProvider = ({ children }) => {
         appendNotification({
           type: NOTIFICATION_TYPES.ERROR,
           message: `Publish Error: Validation Failed for ${modelName}`,
-          details: error.message,
+          details: (
+            <ErrorsCol marginTop="16px">
+              <ErrorsRow>
+                <ErrorLabel>Name: </ErrorLabel>
+                <ErrorText>{modelName}</ErrorText>
+              </ErrorsRow>
+              <ErrorsRow>
+                <ErrorLabel>Errors: </ErrorLabel>
+                <ErrorsCol>
+                  {(error.error.message || []).map((detail, i) => (
+                    <ErrorText key={`${modelName}-error-${i}`}>{detail}</ErrorText>
+                  ))}
+                </ErrorsCol>
+              </ErrorsRow>
+            </ErrorsCol>
+          ),
           timeout: false,
           modelName,
           onClose: () => {
@@ -160,7 +176,7 @@ export const PublishNotificationsProvider = ({ children }) => {
         appendNotification({
           type: NOTIFICATION_TYPES.ERROR,
           message: `Publish Error: An unexpected error occured while publishing ${modelName}`,
-          details: error.message,
+          details: error.error.message,
           timeout: false,
           modelName,
           onClose: () => {
@@ -184,7 +200,7 @@ export const PublishNotificationsProvider = ({ children }) => {
     appendNotification({
       type: NOTIFICATION_TYPES.ERROR,
       message: 'Publish Error: An unexpected error has occurred.',
-      details: error.message || error.details || error.name,
+      details: error?.error?.message || error?.message || error,
       timeout: false,
     });
   };
@@ -249,10 +265,7 @@ export const PublishNotificationsProvider = ({ children }) => {
         removePublishNotification(modelName);
       }
 
-      if (failedPublish.actionable || failedPublish.publishType === PUBLISH_TYPES.individual) {
-        // Actionable errors and errors for individual publishes get shown normally
-        showErrorPublishNotification(modelName, failedPublish);
-      }
+      showErrorPublishNotification(modelName, failedPublish);
     });
   };
 

--- a/ui/src/components/admin/Notifications/PublishProgress.js
+++ b/ui/src/components/admin/Notifications/PublishProgress.js
@@ -1,0 +1,289 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useContext, useEffect, useRef, useState } from 'react';
+
+import {
+  acknowledgeBulkPublishStatus,
+  stopAllPublishes,
+} from 'components/admin/Model/actions/Publish';
+import usePublishNotifications from 'components/admin/Notifications/PublishNotifications';
+import { ModelManagerContext } from 'components/admin/ModelsManager/ModelManagerController';
+import useConfirmationModal from 'components/modals/ConfirmationModal';
+import { NotificationsContext } from './NotificationsController';
+import NOTIFICATION_TYPES from './NotificationTypes';
+
+import CheckmarkIcon from 'icons/CheckmarkIcon';
+import CrossCircleIcon from 'icons/CrossCircleIcon';
+import CrossIcon from 'icons/CrossIcon';
+
+import { ButtonPill } from 'theme/adminControlsStyles';
+import {
+  Notification,
+  Message,
+  Details,
+  closeIcon,
+  closeIconDisabled,
+  ProgressBarContainer,
+  ProgressBarWrapper,
+  ProgressBarSectionComplete,
+  ProgressBarSectionFailed,
+  ProgressBarSectionIncomplete,
+  ProgressBarLabel,
+} from 'theme/adminNotificationStyles';
+import { Row, Col } from 'theme/system';
+import base from 'theme';
+
+import { PUBLISH_STATUS, PUBLISH_TYPES } from 'utils/constants';
+
+const {
+  keyedPalette: { trout },
+} = base;
+
+const BulkPublishState = {
+  complete: 'COMPLETE',
+  stopped: 'STOPPED',
+  publishing: 'PUBLISHING',
+  off: 'OFF',
+};
+
+const PublishProgress = ({ renderIcon }) => {
+  const { publishProgress, location } = useContext(NotificationsContext);
+  const { refreshModelsTable } =
+    location && location.pathname === '/admin'
+      ? // eslint-disable-next-line react-hooks/rules-of-hooks
+        useContext(ModelManagerContext)
+      : { refreshModelsTable: null };
+  const {
+    fetchPublishStatus,
+    showUnexpectedPublishError,
+    hideErrorPublishNotification,
+  } = usePublishNotifications();
+  const [working, setWorking] = useState(false);
+  const prevPublishState = useRef();
+
+  const getBulkPublishes = () => {
+    if (!publishProgress) {
+      return [];
+    }
+
+    return [
+      ...publishProgress.queue,
+      ...publishProgress.failed,
+      ...publishProgress.stopped,
+      ...publishProgress.success,
+    ].filter(x => x.publishType === PUBLISH_TYPES.bulk);
+  };
+
+  const getProgressBannerType = () => {
+    if (!publishProgress) {
+      return false;
+    }
+
+    return publishProgress.running ? NOTIFICATION_TYPES.LOADING : NOTIFICATION_TYPES.SUCCESS;
+  };
+
+  const getProgressBannerDetails = () => {
+    switch (getBulkPublishState()) {
+      case BulkPublishState.publishing:
+        return 'You can continue to use the CMS, and will be notified of the status for each publish. Note that some functionality is unavailable during bulk publish.';
+      case BulkPublishState.complete:
+      case BulkPublishState.stopped:
+        return 'You may resume normal operation of the CMS.';
+      default:
+        // No visible banner for 'OFF'
+        return null;
+    }
+  };
+
+  const getBulkPublishState = () => {
+    if (!publishProgress) {
+      return BulkPublishState.off;
+    }
+
+    if (publishProgress.running && getBulkPublishes().length) {
+      // Bulk publish is currently running
+      return BulkPublishState.publishing;
+    } else if (publishProgress.running && !getBulkPublishes().length) {
+      // Only individual publishes running, no bulk
+      return BulkPublishState.off;
+    } else if (getBulkPublishes().filter(x => x.status === PUBLISH_STATUS.stopped).length) {
+      // Bulk publish has been stopped
+      return BulkPublishState.stopped;
+    } else {
+      // Bulk publish is complete
+      return BulkPublishState.complete;
+    }
+  };
+
+  const getProgressBannerMessage = () => {
+    let completePublishes;
+    switch (getBulkPublishState()) {
+      case BulkPublishState.complete:
+        completePublishes = getBulkPublishes().filter(x => x.status === PUBLISH_STATUS.complete);
+        return `Bulk Publish Complete: ${completePublishes.length} model${
+          completePublishes.length === 1 ? ' has' : 's have'
+        } been published.`;
+      case BulkPublishState.publishing:
+        return `Publishing: ${getBulkPublishes().length} model${
+          getBulkPublishes().length === 1 ? ' is' : 's are'
+        } currently publishing.`;
+      case BulkPublishState.stopped:
+        completePublishes = getBulkPublishes().filter(x => x.status === PUBLISH_STATUS.complete);
+        return `Bulk Publish Stopped: ${completePublishes.length} model${
+          completePublishes.length === 1 ? ' has' : 's have'
+        } successfully published.`;
+      default:
+        // No visible banner for 'OFF'
+        return null;
+    }
+  };
+
+  const ProgressBar = () => {
+    const success = getBulkPublishes().filter(x => x.status === PUBLISH_STATUS.complete);
+    const failed = getBulkPublishes().filter(x => x.status === PUBLISH_STATUS.error);
+    const incomplete = getBulkPublishes().filter(
+      x =>
+        x.status === PUBLISH_STATUS.active ||
+        x.status === PUBLISH_STATUS.waiting ||
+        x.status === PUBLISH_STATUS.stopped,
+    );
+
+    const meta = () => {
+      switch (getBulkPublishState()) {
+        case BulkPublishState.publishing:
+          return `In Progress: ${incomplete.length}`;
+        case BulkPublishState.complete:
+          return `Publish Complete`;
+        case BulkPublishState.stopped:
+          return `Incomplete: ${incomplete.length}`;
+        default:
+          // No visible banner for 'OFF'
+          return null;
+      }
+    };
+
+    useEffect(() => {
+      if (!prevPublishState) {
+        prevPublishState.current = getBulkPublishState();
+        return;
+      }
+
+      if (
+        refreshModelsTable &&
+        (getBulkPublishState() === BulkPublishState.complete ||
+          getBulkPublishState() === BulkPublishState.stopped) &&
+        prevPublishState.current === BulkPublishState.publishing
+      ) {
+        refreshModelsTable();
+      }
+
+      prevPublishState.current = getBulkPublishState();
+    }, [publishProgress, prevPublishState, refreshModelsTable]);
+
+    return (
+      <Row>
+        <Col>
+          <Row>
+            <ProgressBarContainer>
+              <ProgressBarWrapper>
+                <ProgressBarSectionComplete
+                  num={success.length}
+                  total={getBulkPublishes().length}
+                />
+                <ProgressBarSectionFailed num={failed.length} total={getBulkPublishes().length} />
+                <ProgressBarSectionIncomplete
+                  num={incomplete.length}
+                  total={getBulkPublishes().length}
+                />
+              </ProgressBarWrapper>
+            </ProgressBarContainer>
+          </Row>
+          <Row justifyContent={'space-between'}>
+            <ProgressBarLabel>
+              <CheckmarkIcon fill={'#3AB'} width={'10px'} height={'10px'} />
+              Success: {success.length}
+            </ProgressBarLabel>
+            <ProgressBarLabel>
+              <CrossIcon width={'8px'} height={'8px'} />
+              Failed: {failed.length}
+            </ProgressBarLabel>
+          </Row>
+        </Col>
+        <Col>
+          <span style={{ marginLeft: '8px' }}>{meta()}</span>
+        </Col>
+      </Row>
+    );
+  };
+
+  return (
+    <Notification type={getProgressBannerType()}>
+      {renderIcon(getProgressBannerType())}
+      <Col style={{ maxWidth: '50%', width: '100%' }}>
+        <Message>{getProgressBannerMessage()}</Message>
+        <Details>{getProgressBannerDetails()}</Details>
+      </Col>
+      <Col style={{ padding: '0 12px' }}>
+        <ProgressBar />
+      </Col>
+      {getProgressBannerType() === NOTIFICATION_TYPES.LOADING &&
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        useConfirmationModal({
+          title: 'Stop Bulk Publish?',
+          message: 'Are you sure you want to stop this bulk publish?',
+          confirmLabel: 'Yes, Stop',
+          onConfirm: async () => {
+            setWorking(true);
+            stopAllPublishes()
+              .then(async _ => {
+                await fetchPublishStatus();
+                setWorking(false);
+              })
+              .catch(error => {
+                showUnexpectedPublishError(error);
+              });
+          },
+        })(
+          <ButtonPill
+            secondary
+            style={{
+              marginRight: 0,
+              marginLeft: 'auto',
+            }}
+            disabled={working}
+          >
+            Stop Bulk Publish
+          </ButtonPill>,
+        )}
+      {getProgressBannerType() !== NOTIFICATION_TYPES.LOADING && (
+        <CrossCircleIcon
+          width={'17px'}
+          height={'17px'}
+          fill={trout}
+          css={working ? closeIconDisabled : closeIcon}
+          onClick={() => {
+            if (working) {
+              return;
+            }
+
+            setWorking(true);
+            acknowledgeBulkPublishStatus(getBulkPublishes().map(x => x.modelName))
+              .then(async data => {
+                if (data.success) {
+                  // Remove error notifications for acknowledged errors
+                  (data.acknowledged || []).forEach(model => {
+                    hideErrorPublishNotification(model.modelName);
+                  });
+                }
+                await fetchPublishStatus();
+              })
+              .catch(error => {
+                showUnexpectedPublishError(error);
+              });
+          }}
+        />
+      )}
+    </Notification>
+  );
+};
+
+export default PublishProgress;

--- a/ui/src/components/admin/Notifications/index.js
+++ b/ui/src/components/admin/Notifications/index.js
@@ -4,3 +4,8 @@ export { default as NOTIFICATION_TYPES } from './NotificationTypes';
 export {
   default as useGenomicVariantImportNotifications,
 } from './GenomicVariantImportNotifications';
+export {
+  default as usePublishNotifications,
+  PublishNotificationsContext,
+  PublishNotificationsProvider,
+} from './PublishNotifications';

--- a/ui/src/components/admin/index.js
+++ b/ui/src/components/admin/index.js
@@ -2,17 +2,19 @@ import React from 'react';
 
 import AdminView from './AdminView';
 
-import { NotificationsProvider } from './Notifications';
+import { NotificationsProvider, PublishNotificationsProvider } from './Notifications';
 import { LoggedInUserProvider } from '@hcmi-portal/ui/src/components/admin/services/LoggedInUser';
 import { VariantsProvider } from 'providers/Variants';
 
 const Admin = ({ location }) => (
   <NotificationsProvider location={location}>
-    <LoggedInUserProvider>
-      <VariantsProvider>
-        <AdminView location={location} />
-      </VariantsProvider>
-    </LoggedInUserProvider>
+    <PublishNotificationsProvider>
+      <LoggedInUserProvider>
+        <VariantsProvider>
+          <AdminView location={location} />
+        </VariantsProvider>
+      </LoggedInUserProvider>
+    </PublishNotificationsProvider>
   </NotificationsProvider>
 );
 

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -27,7 +27,7 @@ const GDC_MODEL_STATES = {
   noNgcm: 'NO_NGCM',
 };
 
-const DEFAULT_IMPORT_PROGRESS = {
+const DEFAULT_PROGRESS_QUEUES = {
   queue: [],
   failed: [],
   stopped: [],
@@ -49,6 +49,26 @@ const GENOMIC_VARIANTS_IMPORT_ERRORS = {
 };
 
 const imgPath = '/api/data/images';
+
+const PUBLISH_ERRORS = {
+  noMatchingModel: 'NO_MATCHING_MODEL',
+  badRequest: 'BAD_REQUEST',
+  validationErrror: 'VALIDATION_ERROR',
+  unexpected: 'UNEXPECTED',
+};
+
+const PUBLISH_STATUS = {
+  active: 'ACTIVE',
+  complete: 'COMPLETE',
+  error: 'ERROR',
+  stopped: 'STOPPED',
+  waiting: 'WAITING',
+};
+
+const PUBLISH_TYPES = {
+  bulk: 'BULK',
+  individual: 'INDIVIDUAL',
+};
 
 const VARIANT_IMPORT_TYPES = {
   bulk: 'BULK',
@@ -79,7 +99,7 @@ export {
   BULK_NONACTIONABLE_ERROR_ID,
   BULK_UPLOAD_DISPLAY_TYPES,
   BULK_UPLOAD_TYPES,
-  DEFAULT_IMPORT_PROGRESS,
+  DEFAULT_PROGRESS_QUEUES,
   DEFAULT_NONACTIONABLE_IMPORTS,
   GDC_CASE_URL_BASE,
   GDC_FILE_PAGE_URL_BASE,
@@ -87,6 +107,9 @@ export {
   GDC_MODEL_STATES,
   GENOMIC_VARIANTS_IMPORT_ERRORS,
   imgPath,
+  PUBLISH_ERRORS,
+  PUBLISH_STATUS,
+  PUBLISH_TYPES,
   VARIANT_IMPORT_TYPES,
   VARIANT_IMPORT_STATUS,
   VARIANT_OVERWRITE_OPTIONS,


### PR DESCRIPTION
In lieu of a detailed PR description, I've added PR comments on each file (where necessary).

The TL;DR is we've essentially duplicated the async "GDC Variants Importer" and repurposed it as a new async "Publisher" service. This new "Publisher" uses the same queue system, has its own `/publish` router with similar endpoints to the importer, but publishes models to ES instead of importing variants for them.

On the UI we've replaced all calls to the old publish endpoints with calls to the new async endpoints, removed any locking/freezing of the UI when publishing, added a "Publish Progress" banner similar to the one used for GDC import progress, and updated the ModelStatusPill component to display "Publish in Progress" for models that are currently being published.

Due to time constraints, there is quite a bit of code duplication unfortunately. A few import-specific functions/components have been duplicated and had some parts removed and the rest renamed from "import____" to "publish____". A nice refactor/cleanup ticket can be made in the future, but this works for now.

# 🚨 RELEASE INSTRUCTIONS 🚨 #
Once this PR and the HHS Vulnerability Disclosure PR (https://github.com/nci-hcmi-catalog/portal/pull/1010) are merged to `develop`, please do the following:
1. Make and merge a "🔖  Release 1.17.0" PR from `develop` into `master`
2. Make a new Release, tag "1.17.0" off of `master`
3. Provide the following instructions to Cuong for deployment: https://docs.google.com/document/d/1kTUCJmAX5HUygZ4oGdAN3-sZDIV1YrgbD4KxEfPtwp0/edit#

---

### Commits

**♻️ Refactor Individual Model Publishing on Model Edit Page (https://github.com/nci-hcmi-catalog/portal/issues/1000)**
* Change the `Publish` button on the Model Edit page to use the `/action/publish/:modelName` endpoint instead of re-using the same endpoint as the `Save` button but with an extra flag set

**✨ Add New Publish Router (https://github.com/nci-hcmi-catalog/portal/issues/1000)**
* Adds a new `/publish` endpoint and service, mirroring the structure of the GDC Variant Importer, for Asynchronous Publishing

**🐛 Fix Bugs in Async Publisher Service (https://github.com/nci-hcmi-catalog/portal/issues/1000)**
* Add `await` before running validation and creating publish tasks to prevent starting empty publish queue
* Rearrange publish routes to put `/bulk` before `/:name` to prevent overlap

**📝 Update Documentation for Publish Router (https://github.com/nci-hcmi-catalog/portal/issues/1000)**
* Include more details about the routes and their usage

**✨ Async Publishing (https://github.com/nci-hcmi-catalog/portal/issues/1000)**
* Connect the UI to the new Asynchronous Publishing endpoints of the CMS, allowing the user to browse the CMS while publish operations are processing!
* Modify bulk publish route to accept lists of IDs as an alternative to model names
* Add new `PublishNotifications` system to UI, closely following the GDC Variant Import Notifications pattern

**💡 Update Comments** 

**⚡️ Optimize Async Bulk Publishes (https://github.com/nci-hcmi-catalog/portal/issues/1000)**
* Only update gene search indices after all models in a bulk publish are complete