### PR TITLE
🐛 Ensure Table/Model Data Refresh After Publish

### DIFF
--- a/ui/src/components/admin/Model/ModelSingleHeader.js
+++ b/ui/src/components/admin/Model/ModelSingleHeader.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useContext, useEffect, useRef } from 'react';
 import Popup from 'reactjs-popup';
 import { css } from '@emotion/react';
@@ -100,20 +101,19 @@ const ModelSingleHeader = ({ modelName }) => {
   useEffect(() => {
     const refreshModelData = async () => await fetchModelData(modelName);
 
-    if (modelName && isPublishingModel(modelName) && (!publishState || !publishState.current)) {
+    if (modelName && isPublishingModel(modelName)) {
       publishState.current = 'publishing';
     }
 
     if (
       modelName &&
-      publishState.current === 'publishing' &&
+      (publishState.current === 'publishing' || !publishState.current) &&
       publishProgress.success.find(model => model.modelName === modelName)
     ) {
       publishState.current = 'published';
       refreshModelData();
-      return;
     }
-  }, [publishRunning, publishProgress, modelName, isPublishingModel, fetchModelData]);
+  }, [publishRunning, publishProgress]);
 
   return (
     <AdminHeader>

--- a/ui/src/components/admin/Notifications/PublishProgress.js
+++ b/ui/src/components/admin/Notifications/PublishProgress.js
@@ -162,22 +162,17 @@ const PublishProgress = ({ renderIcon }) => {
     };
 
     useEffect(() => {
-      if (!prevPublishState) {
-        prevPublishState.current = getBulkPublishState();
-        return;
-      }
-
       if (
         refreshModelsTable &&
         (getBulkPublishState() === BulkPublishState.complete ||
           getBulkPublishState() === BulkPublishState.stopped) &&
-        prevPublishState.current === BulkPublishState.publishing
+        (prevPublishState.current === BulkPublishState.publishing || !prevPublishState.current)
       ) {
         refreshModelsTable();
       }
 
       prevPublishState.current = getBulkPublishState();
-    }, [publishProgress, prevPublishState, refreshModelsTable]);
+    }, [publishProgress]);
 
     return (
       <Row>


### PR DESCRIPTION
* Fixes a bug where table/model data would not refresh after very fast publishes