### PR TITLE
🗃️ Change 'DNA Methylation Array' to 'DNA Methylation'

### DIFF
--- a/cms/src/schemas/constants.js
+++ b/cms/src/schemas/constants.js
@@ -1721,9 +1721,9 @@ export const molecularCharacterizations = [
   'WXS of parent tumor',
   'WXS of normal',
   'WXS of model',
-  'DNA Methylation Array of parent tumor',
-  'DNA Methylation Array of normal',
-  'DNA Methylation Array of model',
+  'DNA Methylation of parent tumor',
+  'DNA Methylation of normal',
+  'DNA Methylation of model',
   'RNA-seq of parent tumor',
   'RNA-seq of model',
 ];

--- a/cms/variant-migrations/data/molecularCharacterizations-03-21-23.json
+++ b/cms/variant-migrations/data/molecularCharacterizations-03-21-23.json
@@ -1,0 +1,13 @@
+[
+  { "value": "WGS of parent tumor", "dependents": [] },
+  { "value": "WGS of normal", "dependents": [] },
+  { "value": "WGS of model", "dependents": [] },
+  { "value": "WXS of parent tumor", "dependents": [] },
+  { "value": "WXS of normal", "dependents": [] },
+  { "value": "WXS of model", "dependents": [] },
+  { "value": "DNA Methylation of parent tumor", "dependents": [] },
+  { "value": "DNA Methylation of normal", "dependents": [] },
+  { "value": "DNA Methylation of model", "dependents": [] },
+  { "value": "RNA-seq of parent tumor", "dependents": [] },
+  { "value": "RNA-seq of model", "dependents": [] }
+]

--- a/cms/variant-migrations/migrations/20230321213342-update-molecular-characterizations.js
+++ b/cms/variant-migrations/migrations/20230321213342-update-molecular-characterizations.js
@@ -1,0 +1,26 @@
+const dnaMethylationData = require('../data/molecularCharacterizations-03-21-23.json');
+const dnaMethylationArrayData = require('../data/molecularCharacterizations-10-14-21.json');
+
+module.exports = {
+  up(db) {
+    return db.collection('dictionary').updateMany(
+      { 'fields.name': 'molecularCharacterizations' },
+      {
+        $set: {
+          'fields.$.values': dnaMethylationData,
+        },
+      },
+    );
+  },
+
+  down(db) {
+    return db.collection('dictionary').updateMany(
+      { 'fields.name': 'molecularCharacterizations' },
+      {
+        $set: {
+          'fields.$.values': dnaMethylationArrayData,
+        },
+      },
+    );
+  },
+};

--- a/cms/variant-migrations/migrations/20230321214009-rename-dna-methylation.js
+++ b/cms/variant-migrations/migrations/20230321214009-rename-dna-methylation.js
@@ -1,0 +1,50 @@
+const OLD_PARENT_TUMOR = 'DNA Methylation Array of parent tumor';
+const NEW_PARENT_TUMOR = 'DNA Methylation of parent tumor';
+const OLD_NORMAL = 'DNA Methylation Array of normal';
+const NEW_NORMAL = 'DNA Methylation of normal';
+const OLD_MODEL = 'DNA Methylation Array of model';
+const NEW_MODEL = 'DNA Methylation of model';
+
+module.exports = {
+  async up(db) {
+    await db
+      .collection('models')
+      .updateMany(
+        { molecular_characterizations: OLD_PARENT_TUMOR },
+        { $set: { 'molecular_characterizations.$': NEW_PARENT_TUMOR } },
+      );
+    await db
+      .collection('models')
+      .updateMany(
+        { molecular_characterizations: OLD_NORMAL },
+        { $set: { 'molecular_characterizations.$': NEW_NORMAL } },
+      );
+    await db
+      .collection('models')
+      .updateMany(
+        { molecular_characterizations: OLD_MODEL },
+        { $set: { 'molecular_characterizations.$': NEW_MODEL } },
+      );
+  },
+
+  async down(db) {
+    await db
+      .collection('models')
+      .updateMany(
+        { molecular_characterizations: NEW_PARENT_TUMOR },
+        { $set: { 'molecular_characterizations.$': OLD_PARENT_TUMOR } },
+      );
+    await db
+      .collection('models')
+      .updateMany(
+        { molecular_characterizations: NEW_NORMAL },
+        { $set: { 'molecular_characterizations.$': OLD_NORMAL } },
+      );
+    await db
+      .collection('models')
+      .updateMany(
+        { molecular_characterizations: NEW_MODEL },
+        { $set: { 'molecular_characterizations.$': OLD_MODEL } },
+      );
+  },
+};

--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -156,7 +156,7 @@ const MolecularCharacterizationsCell = ({ isAvailable }) => {
 };
 
 const MolecularCharacterizationsTable = ({ characterizations }) => {
-  const CHARS = ['WGS', 'WXS', 'RNA-seq', 'DNA Methylation Array'];
+  const CHARS = ['WGS', 'WXS', 'RNA-seq', 'DNA Methylation'];
   const TYPES = ['model', 'parent tumor', 'normal'];
 
   return (


### PR DESCRIPTION
* Updates Molecular Characterizations to use 'DNA Methylation' instead of 'DNA Methylation Array'
* Migrations to update existing models referencing the old 'Array' terminology

### 🚨 Deploy Instructions 🚨 
1. Run the `20230321213342-update-molecular-characterizations.js`, and `20230321214009-rename-dna-methylation.js` migrations:
```
cd cms/variant-migrations
./../node_modules/.bin/migrate-mongo up -f migrate-mongo-config.js
```
2. Restart the cms service
3. Run the `republish` script
```
ENV={env} npm run republish
```