### PR TITLE
🚚  Update External URLs (#1041)

### DIFF
--- a/ui/src/components/Footer.js
+++ b/ui/src/components/Footer.js
@@ -23,7 +23,7 @@ const Footer = () => (
         <FooterNav>
           <FooterNavItem>
             <FooterLink
-              href="https://ocg.cancer.gov/programs/HCMI"
+              href="https://www.cancer.gov/ccg/research/functional-genomics/hcmi"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -31,8 +31,12 @@ const Footer = () => (
             </FooterLink>
           </FooterNavItem>
           <FooterNavItem>
-            <FooterLink href="https://ocg.cancer.gov/" target="_blank" rel="noopener noreferrer">
-              ocg.cancer.gov
+            <FooterLink
+              href="https://www.cancer.gov/ccg/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Center for Cancer Genomics
             </FooterLink>
           </FooterNavItem>
           <FooterNavItem>
@@ -46,7 +50,7 @@ const Footer = () => (
           </FooterNavItem>
           <FooterNavItem>
             <FooterLink
-              href="https://ocg.cancer.gov/programs/hcmi/frequently-asked-questions"
+              href="https://www.cancer.gov/ccg/research/functional-genomics/hcmi/using-hcmi/searchable-catalog"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -54,7 +58,11 @@ const Footer = () => (
             </FooterLink>
           </FooterNavItem>
           <FooterNavItem>
-            <FooterLink href="mailto:ocg@mail.nih.gov" target="_blank" rel="noopener noreferrer">
+            <FooterLink
+              href="mailto:NCICCGenomics@mail.nih.gov"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Contact Us
             </FooterLink>
           </FooterNavItem>

--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -370,9 +370,7 @@ const Model = ({ modelName }) => (
                         <ExternalLinkPill
                           primary
                           className="model-section__callout-button"
-                          href={
-                            'http://go.atcc.org/HCMIModels?utm_medium=eloqua_landing_page&utm_source=nci&utm_campaign=hcmi_organoid&utm_content=request_additonal_organoids'
-                          }
+                          href="https://www.atcc.org/hcmi-input"
                           target="_blank"
                           rel="noopener noreferrer"
                         >

--- a/ui/src/components/VariantTables.js
+++ b/ui/src/components/VariantTables.js
@@ -58,7 +58,7 @@ const renderVariantBlurb = type => {
           <TooltipLink
             target="_blank"
             rel="noopener noreferrer"
-            href="https://ocg.cancer.gov/programs/hcmi/resources"
+            href="https://www.cancer.gov/ccg/research/functional-genomics/hcmi/using-hcmi/case-report-forms"
           >
             case report forms.
           </TooltipLink>
@@ -72,7 +72,7 @@ const renderVariantBlurb = type => {
           <TooltipLink
             target="_blank"
             rel="noopener noreferrer"
-            href="https://ocg.cancer.gov/programs/hcmi/resources"
+            href="https://www.cancer.gov/ccg/research/functional-genomics/hcmi/using-hcmi/case-report-forms"
           >
             case report forms.
           </TooltipLink>

--- a/ui/src/components/tooltips/index.js
+++ b/ui/src/components/tooltips/index.js
@@ -73,7 +73,7 @@ export const PatientDetailsTooltip = () => (
     <TooltipLink
       target="_blank"
       rel="noopener noreferrer"
-      href="https://ocg.cancer.gov/programs/hcmi/resources"
+      href="https://www.cancer.gov/ccg/research/functional-genomics/hcmi/using-hcmi/case-report-forms"
     >
       case report forms
     </TooltipLink>
@@ -94,7 +94,7 @@ export const ClinicalVariantsTooltip = () => (
     <TooltipLink
       target="_blank"
       rel="noopener noreferrer"
-      href="https://ocg.cancer.gov/programs/hcmi/resources"
+      href="https://www.cancer.gov/ccg/research/functional-genomics/hcmi/using-hcmi/case-report-forms"
     >
       case report forms
     </TooltipLink>
@@ -115,7 +115,7 @@ export const HistopathologicalBiomarkersTooltip = () => (
     <TooltipLink
       target="_blank"
       rel="noopener noreferrer"
-      href="https://ocg.cancer.gov/programs/hcmi/resources"
+      href="https://www.cancer.gov/ccg/research/functional-genomics/hcmi/using-hcmi/case-report-forms"
     >
       case report forms
     </TooltipLink>

--- a/ui/src/theme/searchStyles.js
+++ b/ui/src/theme/searchStyles.js
@@ -914,7 +914,7 @@ export const Footer = styled('footer')`
   width: 100%;
   padding: 0 16px;
 
-  @media screen and (max-width: 1399px) {
+  @media screen and (max-width: 1479px) {
     min-height: 90px;
     flex-direction: column-reverse;
     justify-content: space-around;


### PR DESCRIPTION
Update Footer URLs, "Case Report Forms" URL, and "Visit ATCC to Express Interest" URL. Also updates the Footer responsive breakpoint as a result of the new Footer URL labels being longer.

### 🚨 Deploy Instructions 🚨 
No additional deploy steps are required.