### PR TITLE
🐛 Fix Exports With "Age at Diagnosis" Filter (#1050)

### DIFF
--- a/api/src/dataExport.js
+++ b/api/src/dataExport.js
@@ -37,7 +37,7 @@ dataExportRouter.post('/:projectId/models', async (req, res) => {
     const project = getProject(projectId);
     const es = project.es;
     // sanitize user input
-    const params = getParamsObj(req.sanitize(req.body.params));
+    const params = getParamsObj(decodeLessThanGreaterThan(req.sanitize(req.body.params)));
     logger.debug(`params: ${JSON.stringify(params)}`);
     const file = params.files[0];
     const { index, sqon } = file;
@@ -180,6 +180,10 @@ const buildVariantTsv = async (data, type) => {
 const getParamsObj = params => {
   const paramsObj = JSON.parse(params);
   return paramsObj;
+};
+
+const decodeLessThanGreaterThan = sanitizedParams => {
+  return sanitizedParams.replace(/(&lt;)/g, '<').replace(/(&gt;)/g, '>');
 };
 
 export default dataExportRouter;


### PR DESCRIPTION
* Decodes less than and greater than operators in sanitized SQON before JSON parsing to prevent `Unknown op` error when downloading exports from Arranger

## Context

Eva reported an issue (#1050) where she was unable to download the “Export” TSV from the models table. Turns out it’s an issue with the “Age of Diagnosis” filter sqon.

“Age of Diagnosis” is a numeric facet, so it adds `>=` and/or `<=`  operators to the sqon based on user input.

A couple years ago we [started sanitizing the request params](https://github.com/nci-hcmi-catalog/portal/blob/8f767a5ccfd5e9b6883545ec5d2547adf06167ea/api/src/dataExport.js#L40C53-L40C53) (`req.sanitize(req.body.params)`) to the api endpoint for triggering the TSV download. So it’s going from `<=` to `&lt;=` in the sqon string before being parsed into JSON and sent to arranger to get the data for download. Arranger is [strictly expecting](https://github.com/overture-stack/arranger/blob/00eb3dd9ea097aad8c270cc9764987801e9b0998/modules/server/src/middleware/constants.js#L26) `<=`, not the sanitized version, so it throws an `Unknown op` error and the download fails.

This fix uses a regex to decode the sanitized `&gt;` and `&lt;` back to `>` and `<` for Arranger.

## Deploy Instructions

1. Restart api