### PR TITLE
🗃️ Migrations to Fix DNA Methylation Data Regression (#1054)

### DIFF
--- a/cms/variant-migrations/migrations/20230929213342-update-molecular-characterizations-2.js
+++ b/cms/variant-migrations/migrations/20230929213342-update-molecular-characterizations-2.js
@@ -1,0 +1,27 @@
+// Using the same data for up and down since this is to fix a regression introduced by a devops rollback
+// To revert to the "Array" version of the data, use 20230321213342-update-molecular-characterizations.js
+const dnaMethylationData = require('../data/molecularCharacterizations-03-21-23.json');
+
+module.exports = {
+  up(db) {
+    return db.collection('dictionary').updateMany(
+      { 'fields.name': 'molecularCharacterizations' },
+      {
+        $set: {
+          'fields.$.values': dnaMethylationData,
+        },
+      },
+    );
+  },
+
+  down(db) {
+    return db.collection('dictionary').updateMany(
+      { 'fields.name': 'molecularCharacterizations' },
+      {
+        $set: {
+          'fields.$.values': dnaMethylationData,
+        },
+      },
+    );
+  },
+};

--- a/cms/variant-migrations/migrations/20230929214009-rename-dna-methylation-2.js
+++ b/cms/variant-migrations/migrations/20230929214009-rename-dna-methylation-2.js
@@ -1,0 +1,54 @@
+module.exports = {
+  async up(db) {
+    await db.collection('models').updateMany(
+      {
+        molecular_characterizations: { $regex: /Methylation Array of/ },
+      },
+      [
+        {
+          $set: {
+            molecular_characterizations: {
+              $map: {
+                input: '$molecular_characterizations',
+                as: 'elem',
+                in: {
+                  $replaceOne: {
+                    input: '$$elem',
+                    find: 'Methylation Array of',
+                    replacement: 'Methylation of',
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    );
+  },
+  async down(db) {
+    await db.collection('models').updateMany(
+      {
+        molecular_characterizations: { $regex: /Methylation of/ },
+      },
+      [
+        {
+          $set: {
+            molecular_characterizations: {
+              $map: {
+                input: '$molecular_characterizations',
+                as: 'elem',
+                in: {
+                  $replaceOne: {
+                    input: '$$elem',
+                    find: 'Methylation of',
+                    replacement: 'Methylation Array of',
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    );
+  },
+};


### PR DESCRIPTION
* Migrations to update the Molecular Characterization options and individual model selections after a regression caused old "DNA Methylation Array" data to reappear

# 🚨 DEPLOY INSTRUCTIONS 🚨 #
1. Deploy the new tag through Jenkins
3. Run the `20230929213342-update-molecular-characterizations-2.js`, and `20230929214009-rename-dna-methylation-2.js` migrations:
```
cd cms/variant-migrations
./../node_modules/.bin/migrate-mongo up -f migrate-mongo-config.js
```
4. Restart the cms service
5. Run the `republish` script
```
ENV={env} npm run republish
```