### PR TITLE
🗃️ Migrations to Fix "DNA Methylation Array" Terminology Regression (#1063)

### DIFF
--- a/cms/variant-migrations/migrations/20240109040115-update-models-dna-methylation.js
+++ b/cms/variant-migrations/migrations/20240109040115-update-models-dna-methylation.js
@@ -1,0 +1,54 @@
+module.exports = {
+  async up(db) {
+    await db.collection('models').updateMany(
+      {
+        molecular_characterizations: { $regex: /Methylation Array of/ },
+      },
+      [
+        {
+          $set: {
+            molecular_characterizations: {
+              $map: {
+                input: '$molecular_characterizations',
+                as: 'elem',
+                in: {
+                  $replaceOne: {
+                    input: '$$elem',
+                    find: 'Methylation Array of',
+                    replacement: 'Methylation of',
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    );
+  },
+  async down(db) {
+    await db.collection('models').updateMany(
+      {
+        molecular_characterizations: { $regex: /Methylation of/ },
+      },
+      [
+        {
+          $set: {
+            molecular_characterizations: {
+              $map: {
+                input: '$molecular_characterizations',
+                as: 'elem',
+                in: {
+                  $replaceOne: {
+                    input: '$$elem',
+                    find: 'Methylation of',
+                    replacement: 'Methylation Array of',
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    );
+  },
+};

--- a/cms/variant-migrations/migrations/20240109040219-update-dictionary-dna-methylation.js
+++ b/cms/variant-migrations/migrations/20240109040219-update-dictionary-dna-methylation.js
@@ -1,0 +1,26 @@
+const dnaMethylationData = require('../data/molecularCharacterizations-03-21-23.json');
+const dnaMethylationArrayData = require('../data/molecularCharacterizations-10-14-21.json');
+
+module.exports = {
+  up(db) {
+    return db.collection('dictionary').updateMany(
+      { 'fields.name': 'molecularCharacterizations' },
+      {
+        $set: {
+          'fields.$.values': dnaMethylationData,
+        },
+      },
+    );
+  },
+
+  down(db) {
+    return db.collection('dictionary').updateMany(
+      { 'fields.name': 'molecularCharacterizations' },
+      {
+        $set: {
+          'fields.$.values': dnaMethylationArrayData,
+        },
+      },
+    );
+  },
+};

--- a/cms/variant-migrations/migrations/20240109040313-update-dictionaryDraft-dna-methylation.js
+++ b/cms/variant-migrations/migrations/20240109040313-update-dictionaryDraft-dna-methylation.js
@@ -1,0 +1,26 @@
+const dnaMethylationData = require('../data/molecularCharacterizations-03-21-23.json');
+const dnaMethylationArrayData = require('../data/molecularCharacterizations-10-14-21.json');
+
+module.exports = {
+  up(db) {
+    return db.collection('dictionaryDraft').updateMany(
+      { 'fields.name': 'molecularCharacterizations' },
+      {
+        $set: {
+          'fields.$.values': dnaMethylationData,
+        },
+      },
+    );
+  },
+
+  down(db) {
+    return db.collection('dictionaryDraft').updateMany(
+      { 'fields.name': 'molecularCharacterizations' },
+      {
+        $set: {
+          'fields.$.values': dnaMethylationArrayData,
+        },
+      },
+    );
+  },
+};


### PR DESCRIPTION
The "DNA Methylation Array" molecular characterization terminology regressed again! This time, with Eva's help, we were able to identify the root cause as the Data Dictionary publishing a Draft containing the outdated values. Previously, the migrations had only updated the `models` and the `dictionary`. This time we'll update the `dictionaryDraft` as well, eliminating any traces of the old terminology for good.

## Commits
**🗃️ Migrations to Fix "DNA Methylation Array" Terminology Regression (#1063)**
* Adds three migrations to fix the "DNA Methylation Array" molecular characterization regression that was caused by outdated Dictionary Drafts publishing old values
	* `update-models-dna-methylation` updates any models containing the outdated terminology
	* `update-dictionary-dna-methylation` updates the current Data Dictionary
	* `update-dictionaryDraft-dna-methylation` updates the current Dictionary Draft

## 🚨 DEPLOY INSTRUCTIONS 🚨
1. Deploy the new tag through Jenkins
2. Run the `20240109040115-update-models-dna-methylation.js`, `20240109040219-update-dictionary-dna-methylation.js`, and `20240109040313-update-dictionaryDraft-dna-methylation.js` migrations:
```
cd cms/variant-migrations
./../node_modules/.bin/migrate-mongo up -f migrate-mongo-config.js
```
3. Restart the cms service
4. Run the `republish` script
```
ENV={env} npm run republish
```