### PR TITLE
🗃️ Rewrite Model Sequence URLs to GDC v1

### DIFF
--- a/cms/variant-migrations/migrations/20240226184341-update-models-gdc-v1-sequence-urls.js
+++ b/cms/variant-migrations/migrations/20240226184341-update-models-gdc-v1-sequence-urls.js
@@ -1,0 +1,42 @@
+module.exports = {
+  async up(db) {
+    await db.collection('models').updateMany(
+      {
+        source_sequence_url: { $regex: /https:\/\/portal.gdc.cancer.gov\/repository/ },
+      },
+      [
+        {
+          $set: {
+            source_sequence_url: {
+              $replaceAll: {
+                input: '$source_sequence_url',
+                find: 'https://portal.gdc.cancer.gov/repository',
+                replacement: 'https://portal.gdc.cancer.gov/v1/repository',
+              },
+            },
+          },
+        },
+      ],
+    );
+  },
+  async down(db) {
+    await db.collection('models').updateMany(
+      {
+        source_sequence_url: { $regex: /https:\/\/portal.gdc.cancer.gov\/v1\/repository/ },
+      },
+      [
+        {
+          $set: {
+            source_sequence_url: {
+              $replaceAll: {
+                input: '$source_sequence_url',
+                find: 'https://portal.gdc.cancer.gov/v1/repository',
+                replacement: 'https://portal.gdc.cancer.gov/repository',
+              },
+            },
+          },
+        },
+      ],
+    );
+  },
+};


### PR DESCRIPTION
* Adds a migration to rewrite all model `source_sequence_url`s to use GDC v1

## 🚨 DEPLOY INSTRUCTIONS 🚨
1. Deploy the new tag through Jenkins
2. Run the `20240226184341-update-models-gdc-v1-sequence-urls.js` migration:
```
cd cms/variant-migrations
./../node_modules/.bin/migrate-mongo up -f migrate-mongo-config.js
```
3. Restart the cms service
4. Run the `republish` script
```
ENV={env} npm run republish
```