### PR TITLE
✨ Add Proteomics Data URL to External Resources

### DIFF
--- a/cms/src/helpers/uploadTemplate.js
+++ b/cms/src/helpers/uploadTemplate.js
@@ -46,6 +46,7 @@ export const createModelUploadTemplate = async authClient => {
     'Licensing Required',
     'Matched Model',
     'Somatic MAF URL',
+    'Proteomics URL',
   ];
   // These should match the field names and the order of columnHeaders
   // If it starts with an _ that means it is a placeholder and is not going to be found in the dictionary
@@ -81,6 +82,7 @@ export const createModelUploadTemplate = async authClient => {
     'licensingRequired',
     '_matchedmodel',
     'somatic_maf_url',
+    'proteomics_url',
   ];
   const nonDictionaryModelFields = [
     { name: 'chemotherapeuticDrugs', values: [{ value: 'Yes' }, { value: 'No' }] },

--- a/cms/src/schemas/descriptions/model.js
+++ b/cms/src/schemas/descriptions/model.js
@@ -132,6 +132,10 @@ export const schemaArr = [
     accessor: 'somatic_maf_url',
   },
   {
+    displayName: 'Proteomics URL',
+    accessor: 'proteomics_url',
+  },
+  {
     displayName: 'Has Matched Models',
     accessor: 'has_matched_models',
   },

--- a/cms/src/schemas/model.js
+++ b/cms/src/schemas/model.js
@@ -85,6 +85,7 @@ export const ModelSchema = new mongoose.Schema(
     source_model_url: { type: String, es_indexed: true },
     source_sequence_url: { type: String, es_indexed: true },
     somatic_maf_url: { type: String, es_indexed: true },
+    proteomics_url: { type: String, es_indexed: true },
     expanded: { type: Boolean, es_indexed: true },
     files: { type: [FilesSchema], es_indexed: true },
     variants: { type: [VariantExpression], es_indexed: true },

--- a/cms/src/validation/model.js
+++ b/cms/src/validation/model.js
@@ -179,6 +179,9 @@ export const getPublishSchema = async (excludedNames, dictionary) => {
     somatic_maf_url: string()
       .url()
       .nullable(true),
+    proteomics_url: string()
+      .url()
+      .nullable(true),
     updatedBy: string(),
     status: string(),
     variants: array()
@@ -317,6 +320,9 @@ export const getSaveValidation = async () => {
       .url()
       .nullable(true),
     somatic_maf_url: string()
+      .url()
+      .nullable(true),
+    proteomics_url: string()
       .url()
       .nullable(true),
     updatedBy: string(),

--- a/elasticsearch/arranger_metadata/aggs-state.json
+++ b/elasticsearch/arranger_metadata/aggs-state.json
@@ -165,6 +165,11 @@
     "active": true
   },
   {
+    "field": "proteomics_url",
+    "show": false,
+    "active": true
+  },
+  {
     "field": "source_sequence_url",
     "show": false,
     "active": true

--- a/elasticsearch/arranger_metadata/columns-state.json
+++ b/elasticsearch/arranger_metadata/columns-state.json
@@ -376,6 +376,16 @@
       "canChangeShow": false,
       "query": null,
       "jsonPath": null
+    },
+    {
+      "field": "proteomics_url",
+      "accessor": "proteomics_url",
+      "show": false,
+      "type": "string",
+      "sortable": false,
+      "canChangeShow": false,
+      "query": null,
+      "jsonPath": null
     }
   ],
   "timestamp": "2019-10-11T20:36:07.801Z"

--- a/elasticsearch/arranger_metadata/extended.json
+++ b/elasticsearch/arranger_metadata/extended.json
@@ -517,6 +517,18 @@
     "rangeStep": 1
   },
   {
+    "field": "proteomics_url",
+    "type": "keyword",
+    "displayName": "Link To Proteomics Data",
+    "active": false,
+    "isArray": false,
+    "primaryKey": false,
+    "quickSearchEnabled": false,
+    "unit": null,
+    "displayValues": {},
+    "rangeStep": 1
+  },
+  {
     "field": "source_model_url",
     "type": "keyword",
     "displayName": "Link to Model Details",
@@ -552,7 +564,6 @@
     "displayValues": {},
     "rangeStep": 1
   },
-
   {
     "field": "status",
     "type": "text",

--- a/elasticsearch/modelsIndex.json
+++ b/elasticsearch/modelsIndex.json
@@ -136,6 +136,9 @@
       "primary_site": {
         "type": "keyword"
       },
+      "proteomics_url": {
+        "type": "keyword"
+      },
       "race": {
         "type": "keyword"
       },

--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -204,18 +204,26 @@ const ExternalResourceLink = ({ url, children }) =>
 
 const ExternalResourcesContent = ({
   distributorPartNumber,
+  proteomicsUrl,
+  somaticMafUrl,
   sourceModelUrl,
   sourceSequenceUrl,
-  somaticMafUrl,
 }) => {
-  const sequencingFilesLink = sourceSequenceUrl !== 'N/A' ? sourceSequenceUrl : null;
-  const modelSourceLink = sourceModelUrl !== 'N/A' ? sourceModelUrl : null;
-  const somaticMafLink = somaticMafUrl !== 'N/A' ? somaticMafUrl : null;
   const distributorLinkUrl = distributorPartNumber ? distributorLink(distributorPartNumber) : null;
+  const modelSourceLink = sourceModelUrl !== 'N/A' ? sourceModelUrl : null;
+  const proteomicsLink = proteomicsUrl !== 'N/A' ? proteomicsUrl : null;
+  const sequencingFilesLink = sourceSequenceUrl !== 'N/A' ? sourceSequenceUrl : null;
+  const somaticMafLink = somaticMafUrl !== 'N/A' ? somaticMafUrl : null;
+  const hasExternalResources =
+    distributorLinkUrl ||
+    modelSourceLink ||
+    sequencingFilesLink ||
+    somaticMafLink ||
+    (process.env.REACT_APP_ENABLE_PROTEOMICS && proteomicsLink);
 
   return (
     <div className="external-resources">
-      {!distributorPartNumber && !sequencingFilesLink && !modelSourceLink && !somaticMafLink ? (
+      {!hasExternalResources ? (
         <div className="model-details model-details--empty">
           {/* Manually adding a circle around this icon for the empty state */}
           <div
@@ -251,6 +259,12 @@ const ExternalResourcesContent = ({
             <ExternalLinkIcon />
             Case Metadata
           </ExternalResourceLink>
+          {process.env.REACT_APP_ENABLE_PROTEOMICS && (
+            <ExternalResourceLink url={proteomicsLink}>
+              <ExternalLinkIcon />
+              Proteomics Data
+            </ExternalResourceLink>
+          )}
           <ExternalResourceLink url={somaticMafLink}>
             <ExternalLinkIcon />
             Masked Somatic MAF
@@ -461,6 +475,7 @@ const Model = ({ modelName }) => (
                       <h3 className="model-section__card-title">External Resources</h3>
                       <ExternalResourcesContent
                         distributorPartNumber={get(queryState.model, 'distributor_part_number')}
+                        proteomicsUrl={get(queryState.model, 'proteomics_url')}
                         sourceModelUrl={get(queryState.model, 'source_model_url')}
                         sourceSequenceUrl={get(queryState.model, 'source_sequence_url')}
                         somaticMafUrl={get(queryState.model, 'somatic_maf_url')}

--- a/ui/src/components/admin/Model/ModelForm.js
+++ b/ui/src/components/admin/Model/ModelForm.js
@@ -51,6 +51,7 @@ const {
   source_model_url,
   source_sequence_url,
   somatic_maf_url,
+  proteomics_url,
   expanded,
   updatedAt,
 } = schemaObj;
@@ -430,6 +431,17 @@ const ModelFormTemplate = ({
                     name={source_model_url.accessor}
                     component={FormInput}
                     placeholder={`http://model_url.example.com`}
+                  />
+                </FormComponent>
+
+                <FormComponent
+                  labelText={proteomics_url.displayName}
+                  description="Please provide a url to the GDC webpage containing Proteomics data for this model."
+                >
+                  <Field
+                    name={proteomics_url.accessor}
+                    component={FormInput}
+                    placeholder={`http://proteomics_url.example.com`}
                   />
                 </FormComponent>
               </FormCol>

--- a/ui/src/components/queries/ModelListModalQuery.js
+++ b/ui/src/components/queries/ModelListModalQuery.js
@@ -16,6 +16,7 @@ const fetchData = async ({ setState, modelIds }) => {
                   node {
                     id
                     expanded
+                    proteomics_url
                     source_model_url
                     source_sequence_url
                     somatic_maf_url

--- a/ui/src/components/queries/ModelQuery.js
+++ b/ui/src/components/queries/ModelQuery.js
@@ -17,6 +17,7 @@ const fetchData = async ({ setState, modelName }) => {
                       id
                       expanded
                       distributor_part_number
+                      proteomics_url
                       source_model_url
                       source_sequence_url
                       somatic_maf_url


### PR DESCRIPTION
Adds a new field `proteomics_url` to the model, enabling a new External Resource link on the Model Details page, "Proteomics Data".

* Adds a new field to the model `proteomics_url` for linking to the GDC resources containing the proteomics data for this model
* Updates relevant es/arranger metadata
* Updates CMS to support adding this URL to a model
* Updates the Model Details page to display this link if the `ENABLE_PROTEOMICS` flag is enabled

## 🚨 DEPLOY INSTRUCTIONS 🚨
1. Deploy the new tag through Jenkins
2. Run the `updateEs` script
```
ENV={env} npm run updateEs
```
3. Restart the api and cms services