### PR TITLE
🗃️ Rewrite Model "Sequencing Files" URLs to GDC v2

### DIFF
--- a/cms/src/helpers/genomicVariants.js
+++ b/cms/src/helpers/genomicVariants.js
@@ -67,9 +67,7 @@ const buildVariantId = ({
 
 const buildModelUrl = caseId => `${BASE_GDC_URL}/cases/${caseId}`;
 const buildMafUrl = fileId => `${BASE_GDC_URL}/files/${fileId}`;
-// URL encoded: /v1/repository?facetTab=files&filters={"op":"and","content":[{"op":"in","content":{"field":"cases.case_id","value":["caseId"]}}]}&searchTableTab=files
-const buildSequenceUrl = caseId =>
-  `${BASE_GDC_URL}/v1/repository?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases.case_id%22%2C%22value%22%3A%5B%22${caseId}%22%5D%7D%7D%5D%7D&searchTableTab=files`;
+const buildSequenceUrl = caseId => `${BASE_GDC_URL}/cases/${caseId}#files`;
 
 export const addGenomicVariantsFromMaf = async (name, mafData, { filename, fileId }, caseId) => {
   const model = await Model.findOne({ name });

--- a/cms/variant-migrations/migrations/20240708184150-update-models-gdc-v2-sequence-urls.js
+++ b/cms/variant-migrations/migrations/20240708184150-update-models-gdc-v2-sequence-urls.js
@@ -1,0 +1,46 @@
+module.exports = {
+  async up(db) {
+    const collection = db.collection('models');
+
+    const cursor = collection.find({
+      source_sequence_url: {
+        $regex: /https:\/\/portal\.gdc\.cancer\.gov\/v1\/repository\?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases\.case_id%22%2C%22value%22%3A%5B%22(.*?)%22%5D%7D%7D%5D%7D&searchTableTab=files/,
+      },
+    });
+
+    while (await cursor.hasNext()) {
+      const doc = await cursor.next();
+      const pattern = /https:\/\/portal\.gdc\.cancer\.gov\/v1\/repository\?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases\.case_id%22%2C%22value%22%3A%5B%22(.*?)%22%5D%7D%7D%5D%7D&searchTableTab=files/;
+      const match = doc.source_sequence_url.match(pattern);
+
+      if (match) {
+        const caseId = match[1];
+        const newUrl = `https://portal.gdc.cancer.gov/cases/${caseId}#files`;
+
+        await collection.updateOne({ _id: doc._id }, { $set: { source_sequence_url: newUrl } });
+      }
+    }
+  },
+  async down(db) {
+    const collection = db.collection('models');
+
+    const cursor = collection.find({
+      source_sequence_url: {
+        $regex: /https:\/\/portal\.gdc\.cancer\.gov\/cases\/(.*?)#files/,
+      },
+    });
+
+    while (await cursor.hasNext()) {
+      const doc = await cursor.next();
+      const pattern = /https:\/\/portal\.gdc\.cancer\.gov\/v1\/repository\?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases\.case_id%22%2C%22value%22%3A%5B%22(.*?)%22%5D%7D%7D%5D%7D&searchTableTab=files/;
+      const match = doc.source_sequence_url.match(pattern);
+
+      if (match) {
+        const caseId = match[1];
+        const newUrl = `https://portal.gdc.cancer.gov/v1/repository?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases.case_id%22%2C%22value%22%3A%5B%22${caseId}%22%5D%7D%7D%5D%7D&searchTableTab=files`;
+
+        await collection.updateOne({ _id: doc._id }, { $set: { source_sequence_url: newUrl } });
+      }
+    }
+  },
+};

--- a/cms/variant-migrations/migrations/20240708184150-update-models-gdc-v2-sequence-urls.js
+++ b/cms/variant-migrations/migrations/20240708184150-update-models-gdc-v2-sequence-urls.js
@@ -1,17 +1,19 @@
+const OLD_URL_PATTERN = /https:\/\/portal\.gdc\.cancer\.gov\/v1\/repository\?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases\.case_id%22%2C%22value%22%3A%5B%22(.*?)%22%5D%7D%7D%5D%7D&searchTableTab=files/;
+const NEW_URL_PATTERN = /https:\/\/portal\.gdc\.cancer\.gov\/cases\/(.*?)#files/;
+
 module.exports = {
   async up(db) {
     const collection = db.collection('models');
 
     const cursor = collection.find({
       source_sequence_url: {
-        $regex: /https:\/\/portal\.gdc\.cancer\.gov\/v1\/repository\?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases\.case_id%22%2C%22value%22%3A%5B%22(.*?)%22%5D%7D%7D%5D%7D&searchTableTab=files/,
+        $regex: OLD_URL_PATTERN,
       },
     });
 
     while (await cursor.hasNext()) {
       const doc = await cursor.next();
-      const pattern = /https:\/\/portal\.gdc\.cancer\.gov\/v1\/repository\?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases\.case_id%22%2C%22value%22%3A%5B%22(.*?)%22%5D%7D%7D%5D%7D&searchTableTab=files/;
-      const match = doc.source_sequence_url.match(pattern);
+      const match = doc.source_sequence_url.match(OLD_URL_PATTERN);
 
       if (match) {
         const caseId = match[1];
@@ -26,14 +28,13 @@ module.exports = {
 
     const cursor = collection.find({
       source_sequence_url: {
-        $regex: /https:\/\/portal\.gdc\.cancer\.gov\/cases\/(.*?)#files/,
+        $regex: NEW_URL_PATTERN,
       },
     });
 
     while (await cursor.hasNext()) {
       const doc = await cursor.next();
-      const pattern = /https:\/\/portal\.gdc\.cancer\.gov\/v1\/repository\?facetTab=files&filters=%7B%22op%22%3A%22and%22%2C%22content%22%3A%5B%7B%22op%22%3A%22in%22%2C%22content%22%3A%7B%22field%22%3A%22cases\.case_id%22%2C%22value%22%3A%5B%22(.*?)%22%5D%7D%7D%5D%7D&searchTableTab=files/;
-      const match = doc.source_sequence_url.match(pattern);
+      const match = doc.source_sequence_url.match(NEW_URL_PATTERN);
 
       if (match) {
         const caseId = match[1];


### PR DESCRIPTION
## Context

The HCMI "Model Details" page (e.g. https://hcmi-searchable-catalog.nci.nih.gov/model/HCM-BROD-0648-C71) contains a "Sequencing Files" link under the "External Resources" section that previously pointed to a GDC v1 search filtered on the files related to the GDC Case ID of that model.

With the release of GDC v2, the ability to deep link to a search with file filters was deprecated.

GDC has since added a "Files" table to the "Case" page for a given Case ID, allowing us to link directly to that table and replace the functionality we had with v1.

This PR migrates existing links to the new format, and ensures new links will be created appropriately.

## Changes

* Adds a migration to rewrite existing model `source_sequence_url`s to point to the new Files table on GDC v2's Case ID page
* Updates the automatic GDC Importer to write `source_sequence_url`s using the new v2 format

## 🚨 DEPLOY INSTRUCTIONS 🚨
1. Deploy the new tag through Jenkins
2. Run the `20240708184150-update-models-gdc-v2-sequence-urls` migration:
```
cd cms/variant-migrations
./../node_modules/.bin/migrate-mongo up -f migrate-mongo-config.js
```
3. Restart the cms service
4. Run the `republish` script
```
ENV={env} npm run republish
```