### PR TITLE
♿️ Use `nav` Landmark Element for Admin Navigation

### DIFF
--- a/ui/src/components/admin/AdminNav.js
+++ b/ui/src/components/admin/AdminNav.js
@@ -29,7 +29,7 @@ export const modelEditUrlBase = '/admin/model';
 export const dataDictionaryUrlBase = '/admin/data-dictionary';
 
 const AdminNav = ({ location: { pathname } }) => (
-  <AdminNavWrapper>
+  <AdminNavWrapper as="nav">
     <div>
       <NavLink
         active={isNavLinkActive(pathname, modelsNavPaths) ? `true` : undefined}


### PR DESCRIPTION
* Uses a `nav` tag as the wrapper for the Admin/CMS navigation for better a11y, addressing the "Moderate" issue found in the [axe devtools](https://www.deque.com/axe/devtools/) automated scan for the 2023/2024 508 compliance report