### PR TITLE
💄 Add "External Link" Icon to ATCC External Resource Pill

### DIFF
--- a/ui/src/components/Model.js
+++ b/ui/src/components/Model.js
@@ -271,6 +271,7 @@ const ExternalResourcesContent = ({
           </ExternalResourceLink>
           <ExternalResourceLink url={distributorLinkUrl}>
             <ShoppingCartIcon />
+            <ExternalLinkIcon />
             Visit {distributorPartNumber} to Purchase
           </ExternalResourceLink>
         </>


### PR DESCRIPTION
* Adds the "External Link" icon to the ATCC external resource pill on the Model Details page