### PR TITLE
📌 Pin Arranger 3 Version

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@elastic/elasticsearch": "~7.17.0",
-    "@overture-stack/arranger-server": "^3.0.0-beta.36",
+    "@overture-stack/arranger-server": "3.0.0-beta.36",
     "JSONStream": "^1.3.5",
     "babel-polyfill": "^6.26.0",
     "dotenv": "^5.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
     "@hcmi-portal/cms": "0.0.1",
     "@nivo/bar": "^0.52.0",
     "@nivo/pie": "^0.52.0",
-    "@overture-stack/arranger-components": "^3.0.0-beta.37",
+    "@overture-stack/arranger-components": "3.0.0-beta.37",
     "@react-oauth/google": "^0.2.6",
     "axios": "^0.21.2",
     "downshift": "^1.31.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,7 +2876,7 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@overture-stack/arranger-components@^3.0.0-beta.37":
+"@overture-stack/arranger-components@3.0.0-beta.37":
   version "3.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/@overture-stack/arranger-components/-/arranger-components-3.0.0-beta.37.tgz#fc4e6e86a1a733a8ae4614dd3d0d4289acb98a8d"
   integrity sha512-ezhi9w37sIrNP3BRKwrv/C7Nc24jn3zl65hIhGPQ66ltHNVqHnSwIt7ZKJY7yuSGxhbfkZvyh5a66Ps2+8sFog==
@@ -2923,7 +2923,7 @@
     url-join "^4.0.1"
     uuid "^9.0.0"
 
-"@overture-stack/arranger-server@^3.0.0-beta.36":
+"@overture-stack/arranger-server@3.0.0-beta.36":
   version "3.0.0-beta.36"
   resolved "https://registry.yarnpkg.com/@overture-stack/arranger-server/-/arranger-server-3.0.0-beta.36.tgz#7320167eff6aee187226e81d7955a35b58b8492e"
   integrity sha512-RyB0SrEVbkC5Wh52KZVRy4+azWLL4j9GR1as2MirPyn8zPawxoHyYbWcJy5TgQDQLLw7lzSA83Ds5d7QkZY9UA==


### PR DESCRIPTION
* Pins `@overture-stack/arranger-server` and `@overture-stack/arranger-components` to v3.0.0-beta.36 and v3.0.0-beta.37 respectively
* This avoids the `jsonpath-plus` v10 incompatibility issue with Node.js v16