### PR TITLE
#1116 Update gender displayName

### DIFF
--- a/elasticsearch/arranger_metadata/extended.json
+++ b/elasticsearch/arranger_metadata/extended.json
@@ -150,7 +150,7 @@
     {
       "fieldName": "gender",
       "type": "keyword",
-      "displayName": "Gender",
+      "displayName": "Sex",
       "active": false,
       "isArray": false,
       "primaryKey": false,


### PR DESCRIPTION
Updates Arranger Metadata extended config for field `gender` to display as `Sex`
No changes to Data Dictionary / Model Admin
Issue: https://github.com/nci-hcmi-catalog/portal/issues/1116

🚨 DEPLOYMENT INSTRUCTIONS 🚨
In order to deploy these changes, the following steps need to be run:

Run the updateEs script
`ENV={env} npm run updateEs`