### PR TITLE
🐛🦺 Fix Breaking UI Bugs Related to Unsafe Vanilla JS

### DIFF
--- a/ui/src/components/admin/DeleteModal/DeleteModal.jsx
+++ b/ui/src/components/admin/DeleteModal/DeleteModal.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ModalStateContext } from '~/providers/ModalState';
 import {
   AdminModalStyleNarrow,

--- a/ui/src/components/admin/Model/ModelSingleController.jsx
+++ b/ui/src/components/admin/Model/ModelSingleController.jsx
@@ -546,12 +546,12 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
 
                       await appendNotification({
                         type:
-                          result.errors?.length > 0
+                          result?.errors?.length > 0
                             ? NOTIFICATION_TYPES.WARNING
                             : NOTIFICATION_TYPES.SUCCESS,
                         message: notificationMessage,
                         details: anyUpdatesDone ? '' : extractResultText(result, 'variant'),
-                        bulkErrors: result.errors,
+                        bulkErrors: result?.errors,
                         timeout: false, // do not auto-remove this notification
                       });
                     }),

--- a/ui/src/components/admin/Model/ModelSingleController.jsx
+++ b/ui/src/components/admin/Model/ModelSingleController.jsx
@@ -315,7 +315,7 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
                           (modelDataResponse.data || {}).files || [],
                           (state.data.response || {}).files || [],
                         ) &&
-                          Object.keys(state.form.errors).length === 0) ||
+                          Object.keys(state.form.errors || {}).length === 0) ||
                         state.form.isReadyToPublish,
                     },
                     // Put save response into data
@@ -546,7 +546,7 @@ export const ModelSingleProvider = ({ baseUrl, modelName, children, ...props }) 
 
                       await appendNotification({
                         type:
-                          result.errors.length > 0
+                          result.errors?.length > 0
                             ? NOTIFICATION_TYPES.WARNING
                             : NOTIFICATION_TYPES.SUCCESS,
                         message: notificationMessage,

--- a/ui/src/components/admin/Model/actions/PublishModel.jsx
+++ b/ui/src/components/admin/Model/actions/PublishModel.jsx
@@ -53,7 +53,7 @@ const PublishModel = ({ close, ...props }) => {
       }
       disabled={isReadyToPublish}
     >
-      {Object.keys(errors).length > 0 || !values.name
+      {Object.keys(errors || {}).length > 0 || !values.name
         ? 'Please complete all required fields before publishing'
         : !isReadyToPublish
         ? 'No new changes to publish'

--- a/ui/src/components/admin/ModelsManager/ModelManagerController.jsx
+++ b/ui/src/components/admin/ModelsManager/ModelManagerController.jsx
@@ -76,16 +76,16 @@ const bulkActionCreator =
 
           await appendNotification({
             type:
-              action === 'publish' && errors.length > 0
+              action === 'publish' && errors?.length > 0
                 ? NOTIFICATION_TYPES.WARNING
                 : NOTIFICATION_TYPES.SUCCESS,
             message: `Bulk ${action} complete.`,
             details:
               success +
-              (action === 'publish' && errors.length > 0
-                ? `. ${errors.length} error${errors.length > 1 ? 's' : ''} detected.`
+              (action === 'publish' && errors?.length > 0
+                ? `. ${errors?.length} error${errors?.length > 1 ? 's' : ''} detected.`
                 : ''),
-            bulkErrors: action === 'publish' && errors.length > 0 && errors,
+            bulkErrors: action === 'publish' && errors?.length > 0 && errors,
             timeout: action === 'publish' && errors.length > 0 ? false : 10000, // do not auto-remove this notification when bulk publishing
           });
         }),
@@ -210,7 +210,7 @@ const ModelManagerController = ({ baseUrl, cmsBase, children, ...props }) => (
                             : `Bulk Upload of models has successfully completed. New models or updated fields are saved but not yet published.`;
                           await appendNotification({
                             type:
-                              result.errors.length > 0
+                              result.errors?.length > 0
                                 ? NOTIFICATION_TYPES.WARNING
                                 : NOTIFICATION_TYPES.SUCCESS,
                             message: notificationMessage,

--- a/ui/src/components/admin/ModelsManager/ModelManagerController.jsx
+++ b/ui/src/components/admin/ModelsManager/ModelManagerController.jsx
@@ -210,18 +210,18 @@ const ModelManagerController = ({ baseUrl, cmsBase, children, ...props }) => (
                             : `Bulk Upload of models has successfully completed. New models or updated fields are saved but not yet published.`;
                           await appendNotification({
                             type:
-                              result.errors?.length > 0
+                              result?.errors?.length > 0
                                 ? NOTIFICATION_TYPES.WARNING
                                 : NOTIFICATION_TYPES.SUCCESS,
                             message: notificationMessage,
                             details: anyUpdatesDone ? '' : extractResultText(result),
-                            bulkErrors: result.errors,
+                            bulkErrors: result?.errors,
                             timeout: false, // do not auto-remove this notification
                           });
                           let modelNames;
                           switch (overwriteVariants) {
                             case VARIANT_OVERWRITE_OPTIONS.allModels:
-                              modelNames = [...result.new, ...result.updated, ...result.unchanged];
+                              modelNames = [...result?.new, ...result?.updated, ...result?.unchanged];
                               if (!modelNames.length) {
                                 return;
                               }
@@ -247,7 +247,7 @@ const ModelManagerController = ({ baseUrl, cmsBase, children, ...props }) => (
                                 });
                               break;
                             case VARIANT_OVERWRITE_OPTIONS.cleanOnly:
-                              modelNames = [...result.new, ...result.updated, ...result.unchanged];
+                              modelNames = [...result?.new, ...result?.updated, ...result?.unchanged];
                               if (!modelNames.length) {
                                 return;
                               }

--- a/ui/src/components/admin/helpers/modelForm.js
+++ b/ui/src/components/admin/helpers/modelForm.js
@@ -1,4 +1,4 @@
-export const isFormReadyToSave = (dirty, errors) => dirty && !('name' in errors);
+export const isFormReadyToSave = (dirty, errors) => dirty && !('name' in (errors || {}));
 
 export const isFormReadyToPublish = (values, dirty, errors) =>
-  values.status !== 'published' && !dirty && Object.keys(errors).length === 0;
+  values.status !== 'published' && !dirty && Object.keys(errors || {}).length === 0;


### PR DESCRIPTION
**Note: these might not be the _best_ solutions for all of these, I just wanted to highlight where the issues were (and what they were). Feel free to suggest or push better/cleaner/safer fixes!**

* Re-add `import React from 'react';` to `DeleteModal.jsx`
* Fix breaking bug on Admin forms related to `isFormReadyToSave` helper function (provide empty object fallback for when `errors` is undefined)
* Provide empty object fallback for when `errors` is undefined in `ModelSingleController.jsx`, `PublishModel.jsx`
* Use optional chaining for `errors.length` in `modelForm.js`